### PR TITLE
Add cash register endpoints

### DIFF
--- a/internal/handlers/cash_register.go
+++ b/internal/handlers/cash_register.go
@@ -1,0 +1,140 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"erp-backend/internal/models"
+	"erp-backend/internal/services"
+	"erp-backend/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+type CashRegisterHandler struct {
+	service *services.CashRegisterService
+}
+
+func NewCashRegisterHandler() *CashRegisterHandler {
+	return &CashRegisterHandler{service: services.NewCashRegisterService()}
+}
+
+// GET /cash-registers
+func (h *CashRegisterHandler) GetCashRegisters(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	locationID := c.GetInt("location_id")
+
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	if loc := c.Query("location_id"); loc != "" {
+		if id, err := strconv.Atoi(loc); err == nil {
+			locationID = id
+		}
+	}
+
+	if locationID == 0 {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Location ID required", nil)
+		return
+	}
+
+	registers, err := h.service.GetCashRegisters(companyID, locationID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get cash registers", err)
+		return
+	}
+
+	utils.SuccessResponse(c, "Cash registers retrieved successfully", registers)
+}
+
+// POST /cash-registers/open
+func (h *CashRegisterHandler) OpenCashRegister(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	locationID := c.GetInt("location_id")
+	userID := c.GetInt("user_id")
+
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	if loc := c.Query("location_id"); loc != "" {
+		if id, err := strconv.Atoi(loc); err == nil {
+			locationID = id
+		}
+	}
+
+	if locationID == 0 {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Location ID required", nil)
+		return
+	}
+
+	var req models.OpenCashRegisterRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+
+	if err := utils.ValidateStruct(&req); err != nil {
+		validationErrors := utils.GetValidationErrors(err)
+		utils.ValidationErrorResponse(c, validationErrors)
+		return
+	}
+
+	id, err := h.service.OpenCashRegister(companyID, locationID, userID, req.OpeningBalance)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to open cash register", err)
+		return
+	}
+
+	utils.CreatedResponse(c, "Cash register opened successfully", gin.H{"register_id": id})
+}
+
+// POST /cash-registers/close
+func (h *CashRegisterHandler) CloseCashRegister(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	locationID := c.GetInt("location_id")
+	userID := c.GetInt("user_id")
+
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	if loc := c.Query("location_id"); loc != "" {
+		if id, err := strconv.Atoi(loc); err == nil {
+			locationID = id
+		}
+	}
+
+	if locationID == 0 {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Location ID required", nil)
+		return
+	}
+
+	var req models.CloseCashRegisterRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+
+	if err := utils.ValidateStruct(&req); err != nil {
+		validationErrors := utils.GetValidationErrors(err)
+		utils.ValidationErrorResponse(c, validationErrors)
+		return
+	}
+
+	err := h.service.CloseCashRegister(companyID, locationID, userID, req.ClosingBalance)
+	if err != nil {
+		if err.Error() == "no open cash register" {
+			utils.ErrorResponse(c, http.StatusBadRequest, "No open cash register", err)
+			return
+		}
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to close cash register", err)
+		return
+	}
+
+	utils.SuccessResponse(c, "Cash register closed successfully", nil)
+}

--- a/internal/models/cash_register.go
+++ b/internal/models/cash_register.go
@@ -1,0 +1,27 @@
+package models
+
+import "time"
+
+type CashRegister struct {
+	RegisterID      int       `json:"register_id" db:"register_id"`
+	LocationID      int       `json:"location_id" db:"location_id"`
+	Date            time.Time `json:"date" db:"date"`
+	OpeningBalance  float64   `json:"opening_balance" db:"opening_balance"`
+	ClosingBalance  *float64  `json:"closing_balance,omitempty" db:"closing_balance"`
+	ExpectedBalance float64   `json:"expected_balance" db:"expected_balance"`
+	CashIn          float64   `json:"cash_in" db:"cash_in"`
+	CashOut         float64   `json:"cash_out" db:"cash_out"`
+	Variance        float64   `json:"variance" db:"variance"`
+	OpenedBy        *int      `json:"opened_by,omitempty" db:"opened_by"`
+	ClosedBy        *int      `json:"closed_by,omitempty" db:"closed_by"`
+	Status          string    `json:"status" db:"status"`
+	SyncModel
+}
+
+type OpenCashRegisterRequest struct {
+	OpeningBalance float64 `json:"opening_balance" validate:"required"`
+}
+
+type CloseCashRegisterRequest struct {
+	ClosingBalance float64 `json:"closing_balance" validate:"required"`
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -37,6 +37,7 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 	supplierHandler := handlers.NewSupplierHandler()
 	customerHandler := handlers.NewCustomerHandler()
 	collectionHandler := handlers.NewCollectionHandler()
+	cashRegisterHandler := handlers.NewCashRegisterHandler()
 	// Health check endpoint
 	router.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
@@ -290,6 +291,14 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 				collections.GET("", middleware.RequirePermission("VIEW_COLLECTIONS"), collectionHandler.GetCollections)
 				collections.POST("", middleware.RequirePermission("CREATE_COLLECTIONS"), collectionHandler.CreateCollection)
 				collections.DELETE("/:id", middleware.RequirePermission("DELETE_COLLECTIONS"), collectionHandler.DeleteCollection)
+			}
+
+			cashRegisters := protected.Group("/cash-registers")
+			cashRegisters.Use(middleware.RequireCompanyAccess())
+			{
+				cashRegisters.GET("", middleware.RequirePermission("VIEW_CASH_REGISTERS"), cashRegisterHandler.GetCashRegisters)
+				cashRegisters.POST("/open", middleware.RequirePermission("OPEN_CASH_REGISTER"), cashRegisterHandler.OpenCashRegister)
+				cashRegisters.POST("/close", middleware.RequirePermission("CLOSE_CASH_REGISTER"), cashRegisterHandler.CloseCashRegister)
 			}
 
 			// Supplier management routes (require company)

--- a/internal/services/cash_register_service.go
+++ b/internal/services/cash_register_service.go
@@ -1,0 +1,123 @@
+package services
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"erp-backend/internal/database"
+	"erp-backend/internal/models"
+)
+
+type CashRegisterService struct {
+	db *sql.DB
+}
+
+func NewCashRegisterService() *CashRegisterService {
+	return &CashRegisterService{db: database.GetDB()}
+}
+
+func (s *CashRegisterService) GetCashRegisters(companyID, locationID int) ([]models.CashRegister, error) {
+	query := `
+        SELECT cr.register_id, cr.location_id, cr.date, cr.opening_balance, cr.closing_balance,
+               cr.expected_balance, cr.cash_in, cr.cash_out, cr.variance,
+               cr.opened_by, cr.closed_by, cr.status, cr.sync_status,
+               cr.created_at, cr.updated_at
+        FROM cash_register cr
+        JOIN locations l ON cr.location_id = l.location_id
+        WHERE l.company_id = $1 AND cr.location_id = $2
+        ORDER BY cr.date DESC, cr.register_id DESC`
+
+	rows, err := s.db.Query(query, companyID, locationID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cash registers: %w", err)
+	}
+	defer rows.Close()
+
+	var registers []models.CashRegister
+	for rows.Next() {
+		var cr models.CashRegister
+		err := rows.Scan(
+			&cr.RegisterID, &cr.LocationID, &cr.Date, &cr.OpeningBalance, &cr.ClosingBalance,
+			&cr.ExpectedBalance, &cr.CashIn, &cr.CashOut, &cr.Variance,
+			&cr.OpenedBy, &cr.ClosedBy, &cr.Status, &cr.SyncStatus,
+			&cr.CreatedAt, &cr.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan cash register: %w", err)
+		}
+		registers = append(registers, cr)
+	}
+
+	return registers, nil
+}
+
+func (s *CashRegisterService) OpenCashRegister(companyID, locationID, userID int, openingBalance float64) (int, error) {
+	// Verify location belongs to company
+	var count int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM locations WHERE location_id = $1 AND company_id = $2 AND is_deleted = FALSE`, locationID, companyID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("failed to verify location: %w", err)
+	}
+	if count == 0 {
+		return 0, fmt.Errorf("location not found")
+	}
+
+	// Ensure no open register exists
+	var existing int
+	err = s.db.QueryRow(`SELECT register_id FROM cash_register WHERE location_id = $1 AND status = 'OPEN'`, locationID).Scan(&existing)
+	if err != sql.ErrNoRows {
+		if err == nil {
+			return 0, fmt.Errorf("cash register already open")
+		}
+		return 0, fmt.Errorf("failed to check open register: %w", err)
+	}
+
+	var registerID int
+	err = s.db.QueryRow(`
+        INSERT INTO cash_register (location_id, date, opening_balance, expected_balance, opened_by)
+        VALUES ($1, CURRENT_DATE, $2, $2, $3)
+        RETURNING register_id`,
+		locationID, openingBalance, userID).Scan(&registerID)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open cash register: %w", err)
+	}
+
+	return registerID, nil
+}
+
+func (s *CashRegisterService) CloseCashRegister(companyID, locationID, userID int, closingBalance float64) error {
+	var registerID int
+	var openingBalance, cashIn, cashOut float64
+	err := s.db.QueryRow(`
+        SELECT cr.register_id, cr.opening_balance, cr.cash_in, cr.cash_out
+        FROM cash_register cr
+        JOIN locations l ON cr.location_id = l.location_id
+        WHERE cr.location_id = $1 AND l.company_id = $2 AND cr.status = 'OPEN'
+    `, locationID, companyID).Scan(&registerID, &openingBalance, &cashIn, &cashOut)
+	if err == sql.ErrNoRows {
+		return fmt.Errorf("no open cash register")
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get open register: %w", err)
+	}
+
+	expected := openingBalance + cashIn - cashOut
+	variance := closingBalance - expected
+
+	_, err = s.db.Exec(`
+        UPDATE cash_register
+        SET closing_balance = $1,
+            expected_balance = $2,
+            variance = $3,
+            closed_by = $4,
+            status = 'CLOSED',
+            updated_at = $5
+        WHERE register_id = $6`,
+		closingBalance, expected, variance, userID, time.Now(), registerID)
+	if err != nil {
+		return fmt.Errorf("failed to close cash register: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- implement CashRegister model and request types
- add service and handlers to open, close, and list cash register sessions
- register cash register routes with permissions

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e0dc2c6ec832cac7a7b97af3d14df