### PR TITLE
Add reports endpoints and services

### DIFF
--- a/internal/handlers/reports.go
+++ b/internal/handlers/reports.go
@@ -1,0 +1,143 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"erp-backend/internal/services"
+	"erp-backend/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ReportsHandler handles report related endpoints
+type ReportsHandler struct {
+	reportsService *services.ReportsService
+}
+
+// NewReportsHandler creates a new ReportsHandler
+func NewReportsHandler() *ReportsHandler {
+	return &ReportsHandler{
+		reportsService: services.NewReportsService(),
+	}
+}
+
+// GET /reports/sales-summary
+func (h *ReportsHandler) GetSalesSummary(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	groupBy := c.Query("group_by")
+	if groupBy == "" {
+		utils.ErrorResponse(c, http.StatusBadRequest, "group_by is required", nil)
+		return
+	}
+
+	fromDate := c.Query("from_date")
+	toDate := c.Query("to_date")
+
+	summary, err := h.reportsService.GetSalesSummary(companyID, fromDate, toDate, groupBy)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get sales summary", err)
+		return
+	}
+
+	utils.SuccessResponse(c, "Sales summary retrieved successfully", summary)
+}
+
+// GET /reports/stock-summary
+func (h *ReportsHandler) GetStockSummary(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	var locationID *int
+	if val := c.Query("location_id"); val != "" {
+		if id, err := strconv.Atoi(val); err == nil {
+			locationID = &id
+		}
+	}
+
+	var productID *int
+	if val := c.Query("product_id"); val != "" {
+		if id, err := strconv.Atoi(val); err == nil {
+			productID = &id
+		}
+	}
+
+	summary, err := h.reportsService.GetStockSummary(companyID, locationID, productID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get stock summary", err)
+		return
+	}
+
+	utils.SuccessResponse(c, "Stock summary retrieved successfully", summary)
+}
+
+// GET /reports/top-products
+func (h *ReportsHandler) GetTopProducts(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	fromDate := c.Query("from_date")
+	toDate := c.Query("to_date")
+
+	limit := 10
+	if val := c.Query("limit"); val != "" {
+		if l, err := strconv.Atoi(val); err == nil {
+			limit = l
+		}
+	}
+
+	products, err := h.reportsService.GetTopProducts(companyID, fromDate, toDate, limit)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get top products", err)
+		return
+	}
+
+	utils.SuccessResponse(c, "Top products retrieved successfully", products)
+}
+
+// GET /reports/customer-balances
+func (h *ReportsHandler) GetCustomerBalances(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	balances, err := h.reportsService.GetCustomerBalances(companyID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get customer balances", err)
+		return
+	}
+
+	utils.SuccessResponse(c, "Customer balances retrieved successfully", balances)
+}
+
+// GET /reports/expenses-summary
+func (h *ReportsHandler) GetExpensesSummary(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	groupBy := c.Query("group_by")
+
+	summary, err := h.reportsService.GetExpensesSummary(companyID, groupBy)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get expenses summary", err)
+		return
+	}
+
+	utils.SuccessResponse(c, "Expenses summary retrieved successfully", summary)
+}

--- a/internal/models/reports.go
+++ b/internal/models/reports.go
@@ -1,0 +1,44 @@
+package models
+
+// SalesSummary represents sales totals grouped by a period
+// Used by GET /reports/sales-summary endpoint
+// Period format depends on group_by parameter (day, month, year)
+type SalesSummary struct {
+	Period       string  `json:"period"`
+	TotalSales   float64 `json:"total_sales"`
+	Transactions int     `json:"transactions"`
+}
+
+// StockSummary represents stock levels and values per product/location
+// Used by GET /reports/stock-summary endpoint
+type StockSummary struct {
+	ProductID  int     `json:"product_id"`
+	LocationID int     `json:"location_id"`
+	Quantity   float64 `json:"quantity"`
+	StockValue float64 `json:"stock_value"`
+}
+
+// TopProduct represents top selling product information
+// Used by GET /reports/top-products endpoint
+type TopProduct struct {
+	ProductID    *int    `json:"product_id,omitempty"`
+	ProductName  string  `json:"product_name"`
+	QuantitySold float64 `json:"quantity_sold"`
+	Revenue      float64 `json:"revenue"`
+}
+
+// CustomerBalance represents outstanding balance for a customer
+// Used by GET /reports/customer-balances endpoint
+type CustomerBalance struct {
+	CustomerID int     `json:"customer_id"`
+	Name       string  `json:"name"`
+	TotalDue   float64 `json:"total_due"`
+}
+
+// ExpensesSummary represents summarized expenses grouped by category and/or period
+// Used by GET /reports/expenses-summary endpoint
+type ExpensesSummary struct {
+	Category    string  `json:"category"`
+	TotalAmount float64 `json:"total_amount"`
+	Period      *string `json:"period,omitempty"`
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -38,6 +38,7 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 	customerHandler := handlers.NewCustomerHandler()
 	collectionHandler := handlers.NewCollectionHandler()
 	cashRegisterHandler := handlers.NewCashRegisterHandler()
+	reportsHandler := handlers.NewReportsHandler()
 	// Health check endpoint
 	router.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
@@ -299,6 +300,16 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 				cashRegisters.GET("", middleware.RequirePermission("VIEW_CASH_REGISTERS"), cashRegisterHandler.GetCashRegisters)
 				cashRegisters.POST("/open", middleware.RequirePermission("OPEN_CASH_REGISTER"), cashRegisterHandler.OpenCashRegister)
 				cashRegisters.POST("/close", middleware.RequirePermission("CLOSE_CASH_REGISTER"), cashRegisterHandler.CloseCashRegister)
+			}
+
+			reports := protected.Group("/reports")
+			reports.Use(middleware.RequireCompanyAccess())
+			{
+				reports.GET("/sales-summary", middleware.RequirePermission("VIEW_REPORTS"), reportsHandler.GetSalesSummary)
+				reports.GET("/stock-summary", middleware.RequirePermission("VIEW_REPORTS"), reportsHandler.GetStockSummary)
+				reports.GET("/top-products", middleware.RequirePermission("VIEW_REPORTS"), reportsHandler.GetTopProducts)
+				reports.GET("/customer-balances", middleware.RequirePermission("VIEW_REPORTS"), reportsHandler.GetCustomerBalances)
+				reports.GET("/expenses-summary", middleware.RequirePermission("VIEW_REPORTS"), reportsHandler.GetExpensesSummary)
 			}
 
 			// Supplier management routes (require company)

--- a/internal/services/reports_service.go
+++ b/internal/services/reports_service.go
@@ -1,0 +1,250 @@
+package services
+
+import (
+	"database/sql"
+	"fmt"
+
+	"erp-backend/internal/database"
+	"erp-backend/internal/models"
+)
+
+// ReportsService provides report related operations
+// It aggregates data across modules for analytics
+// Each method matches a reports endpoint
+
+type ReportsService struct {
+	db *sql.DB
+}
+
+// NewReportsService creates a new ReportsService
+func NewReportsService() *ReportsService {
+	return &ReportsService{db: database.GetDB()}
+}
+
+// GetSalesSummary returns total sales grouped by period
+func (s *ReportsService) GetSalesSummary(companyID int, fromDate, toDate, groupBy string) ([]models.SalesSummary, error) {
+	var dateFormat string
+	switch groupBy {
+	case "day":
+		dateFormat = "YYYY-MM-DD"
+	case "month":
+		dateFormat = "YYYY-MM"
+	case "year":
+		dateFormat = "YYYY"
+	default:
+		return nil, fmt.Errorf("invalid group_by")
+	}
+
+	query := fmt.Sprintf(`
+        SELECT TO_CHAR(s.sale_date, '%s') AS period,
+               SUM(s.total_amount) AS total_sales,
+               COUNT(*) AS transactions
+        FROM sales s
+        JOIN locations l ON s.location_id = l.location_id
+        WHERE l.company_id = $1 AND s.is_deleted = FALSE
+    `, dateFormat)
+
+	args := []interface{}{companyID}
+	idx := 2
+	if fromDate != "" {
+		query += fmt.Sprintf(" AND s.sale_date >= $%d", idx)
+		args = append(args, fromDate)
+		idx++
+	}
+	if toDate != "" {
+		query += fmt.Sprintf(" AND s.sale_date <= $%d", idx)
+		args = append(args, toDate)
+		idx++
+	}
+
+	query += " GROUP BY period ORDER BY period"
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get sales summary: %w", err)
+	}
+	defer rows.Close()
+
+	var summaries []models.SalesSummary
+	for rows.Next() {
+		var summary models.SalesSummary
+		if err := rows.Scan(&summary.Period, &summary.TotalSales, &summary.Transactions); err != nil {
+			return nil, fmt.Errorf("failed to scan sales summary: %w", err)
+		}
+		summaries = append(summaries, summary)
+	}
+	return summaries, nil
+}
+
+// GetStockSummary returns stock levels and values
+func (s *ReportsService) GetStockSummary(companyID int, locationID, productID *int) ([]models.StockSummary, error) {
+	query := `
+        SELECT st.product_id, st.location_id, st.quantity,
+               st.quantity * COALESCE(p.cost_price,0) AS stock_value
+        FROM stock st
+        JOIN locations l ON st.location_id = l.location_id
+        JOIN products p ON st.product_id = p.product_id
+        WHERE l.company_id = $1
+    `
+
+	args := []interface{}{companyID}
+	idx := 2
+	if locationID != nil {
+		query += fmt.Sprintf(" AND st.location_id = $%d", idx)
+		args = append(args, *locationID)
+		idx++
+	}
+	if productID != nil {
+		query += fmt.Sprintf(" AND st.product_id = $%d", idx)
+		args = append(args, *productID)
+		idx++
+	}
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get stock summary: %w", err)
+	}
+	defer rows.Close()
+
+	var summaries []models.StockSummary
+	for rows.Next() {
+		var summary models.StockSummary
+		if err := rows.Scan(&summary.ProductID, &summary.LocationID, &summary.Quantity, &summary.StockValue); err != nil {
+			return nil, fmt.Errorf("failed to scan stock summary: %w", err)
+		}
+		summaries = append(summaries, summary)
+	}
+	return summaries, nil
+}
+
+// GetTopProducts returns top selling products
+func (s *ReportsService) GetTopProducts(companyID int, fromDate, toDate string, limit int) ([]models.TopProduct, error) {
+	query := `
+        SELECT sd.product_id, COALESCE(p.name, sd.product_name) AS product_name,
+               SUM(sd.quantity) AS quantity_sold, SUM(sd.line_total) AS revenue
+        FROM sale_details sd
+        JOIN sales s ON sd.sale_id = s.sale_id
+        JOIN locations l ON s.location_id = l.location_id
+        LEFT JOIN products p ON sd.product_id = p.product_id
+        WHERE l.company_id = $1 AND s.is_deleted = FALSE
+    `
+
+	args := []interface{}{companyID}
+	idx := 2
+	if fromDate != "" {
+		query += fmt.Sprintf(" AND s.sale_date >= $%d", idx)
+		args = append(args, fromDate)
+		idx++
+	}
+	if toDate != "" {
+		query += fmt.Sprintf(" AND s.sale_date <= $%d", idx)
+		args = append(args, toDate)
+		idx++
+	}
+
+	query += " GROUP BY sd.product_id, product_name ORDER BY revenue DESC LIMIT $" + fmt.Sprint(idx)
+	args = append(args, limit)
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get top products: %w", err)
+	}
+	defer rows.Close()
+
+	var products []models.TopProduct
+	for rows.Next() {
+		var p models.TopProduct
+		var productID sql.NullInt64
+		if err := rows.Scan(&productID, &p.ProductName, &p.QuantitySold, &p.Revenue); err != nil {
+			return nil, fmt.Errorf("failed to scan top product: %w", err)
+		}
+		if productID.Valid {
+			id := int(productID.Int64)
+			p.ProductID = &id
+		}
+		products = append(products, p)
+	}
+	return products, nil
+}
+
+// GetCustomerBalances returns outstanding balances per customer
+func (s *ReportsService) GetCustomerBalances(companyID int) ([]models.CustomerBalance, error) {
+	query := `
+        SELECT c.customer_id, c.name,
+               COALESCE(SUM(s.total_amount - s.paid_amount),0) AS total_due
+        FROM customers c
+        LEFT JOIN sales s ON c.customer_id = s.customer_id AND s.is_deleted = FALSE
+        WHERE c.company_id = $1 AND c.is_deleted = FALSE
+        GROUP BY c.customer_id, c.name
+        HAVING COALESCE(SUM(s.total_amount - s.paid_amount),0) > 0
+        ORDER BY c.name
+    `
+
+	rows, err := s.db.Query(query, companyID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get customer balances: %w", err)
+	}
+	defer rows.Close()
+
+	var balances []models.CustomerBalance
+	for rows.Next() {
+		var b models.CustomerBalance
+		if err := rows.Scan(&b.CustomerID, &b.Name, &b.TotalDue); err != nil {
+			return nil, fmt.Errorf("failed to scan customer balance: %w", err)
+		}
+		balances = append(balances, b)
+	}
+	return balances, nil
+}
+
+// GetExpensesSummary returns summarized expenses grouped by category and/or period
+func (s *ReportsService) GetExpensesSummary(companyID int, groupBy string) ([]models.ExpensesSummary, error) {
+	query := `SELECT ec.name AS category, SUM(e.amount) AS total_amount`
+	var periodExpr string
+	switch groupBy {
+	case "day":
+		periodExpr = "TO_CHAR(e.expense_date, 'YYYY-MM-DD')"
+	case "month":
+		periodExpr = "TO_CHAR(e.expense_date, 'YYYY-MM')"
+	}
+	if periodExpr != "" {
+		query += ", " + periodExpr + " AS period"
+	}
+	query += `
+        FROM expenses e
+        JOIN locations l ON e.location_id = l.location_id
+        JOIN expense_categories ec ON e.category_id = ec.category_id
+        WHERE l.company_id = $1 AND e.is_deleted = FALSE
+        GROUP BY ec.name`
+	if periodExpr != "" {
+		query += ", period"
+	}
+	query += " ORDER BY ec.name"
+
+	rows, err := s.db.Query(query, companyID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get expenses summary: %w", err)
+	}
+	defer rows.Close()
+
+	var summaries []models.ExpensesSummary
+	for rows.Next() {
+		var ssum models.ExpensesSummary
+		var period sql.NullString
+		if periodExpr != "" {
+			if err := rows.Scan(&ssum.Category, &ssum.TotalAmount, &period); err != nil {
+				return nil, fmt.Errorf("failed to scan expenses summary: %w", err)
+			}
+			if period.Valid {
+				p := period.String
+				ssum.Period = &p
+			}
+		} else {
+			if err := rows.Scan(&ssum.Category, &ssum.TotalAmount); err != nil {
+				return nil, fmt.Errorf("failed to scan expenses summary: %w", err)
+			}
+		}
+		summaries = append(summaries, ssum)
+	}
+	return summaries, nil
+}


### PR DESCRIPTION
## Summary
- implement report models and services for sales, stock, top products, customer balances, and expenses summaries
- expose new report handler and routes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e1718880c832ca79760dd930186c2