### PR TITLE
Add HR employee and payroll endpoints

### DIFF
--- a/internal/handlers/employee.go
+++ b/internal/handlers/employee.go
@@ -1,0 +1,124 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"erp-backend/internal/models"
+	"erp-backend/internal/services"
+	"erp-backend/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+type EmployeeHandler struct {
+	employeeService *services.EmployeeService
+}
+
+func NewEmployeeHandler() *EmployeeHandler {
+	return &EmployeeHandler{employeeService: services.NewEmployeeService()}
+}
+
+// GET /employees
+func (h *EmployeeHandler) GetEmployees(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	filters := map[string]string{}
+	if dept := c.Query("department"); dept != "" {
+		filters["department"] = dept
+	}
+	if status := c.Query("status"); status != "" {
+		filters["status"] = status
+	}
+	employees, err := h.employeeService.GetEmployees(companyID, filters)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get employees", err)
+		return
+	}
+	utils.SuccessResponse(c, "Employees retrieved successfully", employees)
+}
+
+// POST /employees
+func (h *EmployeeHandler) CreateEmployee(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	var req models.CreateEmployeeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	if err := utils.ValidateStruct(&req); err != nil {
+		utils.ValidationErrorResponse(c, utils.GetValidationErrors(err))
+		return
+	}
+	userID := c.GetInt("user_id")
+	// userID not used in creation? We don't use but we keep for consistency? but we don't need.
+	_ = userID
+	employee, err := h.employeeService.CreateEmployee(companyID, &req)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to create employee", err)
+		return
+	}
+	utils.CreatedResponse(c, "Employee created", employee)
+}
+
+// PUT /employees/:id
+func (h *EmployeeHandler) UpdateEmployee(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	employeeID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid employee ID", err)
+		return
+	}
+	var req models.UpdateEmployeeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	if err := utils.ValidateStruct(&req); err != nil {
+		utils.ValidationErrorResponse(c, utils.GetValidationErrors(err))
+		return
+	}
+	if err := h.employeeService.UpdateEmployee(employeeID, companyID, &req); err != nil {
+		if err.Error() == "employee not found" {
+			utils.NotFoundResponse(c, "Employee not found")
+			return
+		}
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to update employee", err)
+		return
+	}
+	utils.SuccessResponse(c, "Employee updated", nil)
+}
+
+// DELETE /employees/:id
+func (h *EmployeeHandler) DeleteEmployee(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	employeeID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid employee ID", err)
+		return
+	}
+	if err := h.employeeService.DeleteEmployee(employeeID, companyID); err != nil {
+		if err.Error() == "employee not found" {
+			utils.NotFoundResponse(c, "Employee not found")
+			return
+		}
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to delete employee", err)
+		return
+	}
+	utils.SuccessResponse(c, "Employee deleted", nil)
+}

--- a/internal/handlers/payroll.go
+++ b/internal/handlers/payroll.go
@@ -1,0 +1,94 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"erp-backend/internal/models"
+	"erp-backend/internal/services"
+	"erp-backend/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+type PayrollHandler struct {
+	payrollService *services.PayrollService
+}
+
+func NewPayrollHandler() *PayrollHandler {
+	return &PayrollHandler{payrollService: services.NewPayrollService()}
+}
+
+// GET /payrolls
+func (h *PayrollHandler) GetPayrolls(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	filters := map[string]string{}
+	if empID := c.Query("employee_id"); empID != "" {
+		filters["employee_id"] = empID
+	}
+	if month := c.Query("month"); month != "" {
+		filters["month"] = month
+	}
+	payrolls, err := h.payrollService.GetPayrolls(companyID, filters)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get payrolls", err)
+		return
+	}
+	utils.SuccessResponse(c, "Payrolls retrieved successfully", payrolls)
+}
+
+// POST /payrolls
+func (h *PayrollHandler) CreatePayroll(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	var req models.CreatePayrollRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	if err := utils.ValidateStruct(&req); err != nil {
+		utils.ValidationErrorResponse(c, utils.GetValidationErrors(err))
+		return
+	}
+	userID := c.GetInt("user_id")
+	payroll, err := h.payrollService.CreatePayroll(companyID, &req, userID)
+	if err != nil {
+		if err.Error() == "employee not found" {
+			utils.NotFoundResponse(c, "Employee not found")
+			return
+		}
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to create payroll", err)
+		return
+	}
+	utils.CreatedResponse(c, "Payroll generated", payroll)
+}
+
+// PUT /payrolls/:id/mark-paid
+func (h *PayrollHandler) MarkPayrollPaid(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	payrollID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid payroll ID", err)
+		return
+	}
+	if err := h.payrollService.MarkPayrollPaid(payrollID, companyID); err != nil {
+		if err.Error() == "payroll not found" {
+			utils.NotFoundResponse(c, "Payroll not found")
+			return
+		}
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to mark payroll paid", err)
+		return
+	}
+	utils.SuccessResponse(c, "Payroll marked as paid", nil)
+}

--- a/internal/models/employee.go
+++ b/internal/models/employee.go
@@ -1,0 +1,48 @@
+package models
+
+import "time"
+
+type Employee struct {
+	EmployeeID   int        `json:"employee_id" db:"employee_id"`
+	CompanyID    int        `json:"company_id" db:"company_id"`
+	LocationID   *int       `json:"location_id,omitempty" db:"location_id"`
+	EmployeeCode *string    `json:"employee_code,omitempty" db:"employee_code"`
+	Name         string     `json:"name" db:"name" validate:"required,min=2,max=255"`
+	Phone        *string    `json:"phone,omitempty" db:"phone"`
+	Email        *string    `json:"email,omitempty" db:"email" validate:"omitempty,email"`
+	Address      *string    `json:"address,omitempty" db:"address"`
+	Position     *string    `json:"position,omitempty" db:"position"`
+	Department   *string    `json:"department,omitempty" db:"department"`
+	Salary       *float64   `json:"salary,omitempty" db:"salary"`
+	HireDate     *time.Time `json:"hire_date,omitempty" db:"hire_date"`
+	IsActive     bool       `json:"is_active" db:"is_active"`
+	SyncModel
+}
+
+type CreateEmployeeRequest struct {
+	LocationID   *int       `json:"location_id,omitempty"`
+	EmployeeCode *string    `json:"employee_code,omitempty"`
+	Name         string     `json:"name" validate:"required,min=2,max=255"`
+	Phone        *string    `json:"phone,omitempty"`
+	Email        *string    `json:"email,omitempty" validate:"omitempty,email"`
+	Address      *string    `json:"address,omitempty"`
+	Position     *string    `json:"position,omitempty"`
+	Department   *string    `json:"department,omitempty"`
+	Salary       *float64   `json:"salary,omitempty"`
+	HireDate     *time.Time `json:"hire_date,omitempty"`
+	IsActive     *bool      `json:"is_active,omitempty"`
+}
+
+type UpdateEmployeeRequest struct {
+	LocationID   *int       `json:"location_id,omitempty"`
+	EmployeeCode *string    `json:"employee_code,omitempty"`
+	Name         *string    `json:"name,omitempty" validate:"omitempty,min=2,max=255"`
+	Phone        *string    `json:"phone,omitempty"`
+	Email        *string    `json:"email,omitempty" validate:"omitempty,email"`
+	Address      *string    `json:"address,omitempty"`
+	Position     *string    `json:"position,omitempty"`
+	Department   *string    `json:"department,omitempty"`
+	Salary       *float64   `json:"salary,omitempty"`
+	HireDate     *time.Time `json:"hire_date,omitempty"`
+	IsActive     *bool      `json:"is_active,omitempty"`
+}

--- a/internal/models/payroll.go
+++ b/internal/models/payroll.go
@@ -1,0 +1,25 @@
+package models
+
+import "time"
+
+type Payroll struct {
+	PayrollID       int       `json:"payroll_id" db:"payroll_id"`
+	EmployeeID      int       `json:"employee_id" db:"employee_id"`
+	PayPeriodStart  time.Time `json:"pay_period_start" db:"pay_period_start"`
+	PayPeriodEnd    time.Time `json:"pay_period_end" db:"pay_period_end"`
+	BasicSalary     float64   `json:"basic_salary" db:"basic_salary"`
+	GrossSalary     float64   `json:"gross_salary" db:"gross_salary"`
+	TotalDeductions float64   `json:"total_deductions" db:"total_deductions"`
+	NetSalary       float64   `json:"net_salary" db:"net_salary"`
+	Status          string    `json:"status" db:"status"`
+	ProcessedBy     *int      `json:"processed_by,omitempty" db:"processed_by"`
+	SyncModel
+}
+
+type CreatePayrollRequest struct {
+	EmployeeID  int     `json:"employee_id" validate:"required"`
+	Month       string  `json:"month" validate:"required"`
+	BasicSalary float64 `json:"basic_salary" validate:"required,gte=0"`
+	Allowances  float64 `json:"allowances" validate:"gte=0"`
+	Deductions  float64 `json:"deductions" validate:"gte=0"`
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -39,6 +39,8 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 	collectionHandler := handlers.NewCollectionHandler()
 	cashRegisterHandler := handlers.NewCashRegisterHandler()
 	reportsHandler := handlers.NewReportsHandler()
+	employeeHandler := handlers.NewEmployeeHandler()
+	payrollHandler := handlers.NewPayrollHandler()
 	// Health check endpoint
 	router.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
@@ -283,6 +285,25 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 				customers.POST("", middleware.RequirePermission("CREATE_CUSTOMERS"), customerHandler.CreateCustomer)
 				customers.PUT("/:id", middleware.RequirePermission("UPDATE_CUSTOMERS"), customerHandler.UpdateCustomer)
 				customers.DELETE("/:id", middleware.RequirePermission("DELETE_CUSTOMERS"), customerHandler.DeleteCustomer)
+			}
+
+			// Employee management routes (require company)
+			employees := protected.Group("/employees")
+			employees.Use(middleware.RequireCompanyAccess())
+			{
+				employees.GET("", middleware.RequirePermission("VIEW_EMPLOYEES"), employeeHandler.GetEmployees)
+				employees.POST("", middleware.RequirePermission("CREATE_EMPLOYEES"), employeeHandler.CreateEmployee)
+				employees.PUT("/:id", middleware.RequirePermission("UPDATE_EMPLOYEES"), employeeHandler.UpdateEmployee)
+				employees.DELETE("/:id", middleware.RequirePermission("DELETE_EMPLOYEES"), employeeHandler.DeleteEmployee)
+			}
+
+			// Payroll routes (require company)
+			payrolls := protected.Group("/payrolls")
+			payrolls.Use(middleware.RequireCompanyAccess())
+			{
+				payrolls.GET("", middleware.RequirePermission("VIEW_PAYROLLS"), payrollHandler.GetPayrolls)
+				payrolls.POST("", middleware.RequirePermission("CREATE_PAYROLLS"), payrollHandler.CreatePayroll)
+				payrolls.PUT("/:id/mark-paid", middleware.RequirePermission("PROCESS_PAYROLLS"), payrollHandler.MarkPayrollPaid)
 			}
 
 			// Collection routes (require company)

--- a/internal/services/employee_service.go
+++ b/internal/services/employee_service.go
@@ -1,0 +1,189 @@
+package services
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"erp-backend/internal/database"
+	"erp-backend/internal/models"
+)
+
+type EmployeeService struct {
+	db *sql.DB
+}
+
+func NewEmployeeService() *EmployeeService {
+	return &EmployeeService{db: database.GetDB()}
+}
+
+func (s *EmployeeService) GetEmployees(companyID int, filters map[string]string) ([]models.Employee, error) {
+	query := `
+                SELECT employee_id, company_id, location_id, employee_code, name, phone, email,
+                       address, position, department, salary, hire_date, is_active,
+                       sync_status, created_at, updated_at, is_deleted
+                FROM employees
+                WHERE company_id = $1 AND is_deleted = FALSE`
+	args := []interface{}{companyID}
+	argPos := 1
+	if dept := filters["department"]; dept != "" {
+		argPos++
+		query += fmt.Sprintf(" AND department = $%d", argPos)
+		args = append(args, dept)
+	}
+	if status := filters["status"]; status != "" {
+		argPos++
+		query += fmt.Sprintf(" AND is_active = $%d", argPos)
+		args = append(args, status == "active")
+	}
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get employees: %w", err)
+	}
+	defer rows.Close()
+
+	var employees []models.Employee
+	for rows.Next() {
+		var e models.Employee
+		if err := rows.Scan(
+			&e.EmployeeID, &e.CompanyID, &e.LocationID, &e.EmployeeCode, &e.Name,
+			&e.Phone, &e.Email, &e.Address, &e.Position, &e.Department,
+			&e.Salary, &e.HireDate, &e.IsActive, &e.SyncStatus, &e.CreatedAt, &e.UpdatedAt, &e.IsDeleted,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan employee: %w", err)
+		}
+		employees = append(employees, e)
+	}
+	return employees, nil
+}
+
+func (s *EmployeeService) CreateEmployee(companyID int, req *models.CreateEmployeeRequest) (*models.Employee, error) {
+	isActive := true
+	if req.IsActive != nil {
+		isActive = *req.IsActive
+	}
+	query := `
+                INSERT INTO employees (company_id, location_id, employee_code, name, phone, email, address,
+                                       position, department, salary, hire_date, is_active)
+                VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+                RETURNING employee_id, created_at`
+	var emp models.Employee
+	err := s.db.QueryRow(query,
+		companyID, req.LocationID, req.EmployeeCode, req.Name, req.Phone, req.Email, req.Address,
+		req.Position, req.Department, req.Salary, req.HireDate, isActive,
+	).Scan(&emp.EmployeeID, &emp.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create employee: %w", err)
+	}
+	emp.CompanyID = companyID
+	emp.LocationID = req.LocationID
+	emp.EmployeeCode = req.EmployeeCode
+	emp.Name = req.Name
+	emp.Phone = req.Phone
+	emp.Email = req.Email
+	emp.Address = req.Address
+	emp.Position = req.Position
+	emp.Department = req.Department
+	emp.Salary = req.Salary
+	emp.HireDate = req.HireDate
+	emp.IsActive = isActive
+	return &emp, nil
+}
+
+func (s *EmployeeService) UpdateEmployee(employeeID, companyID int, req *models.UpdateEmployeeRequest) error {
+	updates := []string{}
+	args := []interface{}{}
+	argPos := 1
+	if req.LocationID != nil {
+		updates = append(updates, fmt.Sprintf("location_id = $%d", argPos))
+		args = append(args, *req.LocationID)
+		argPos++
+	}
+	if req.EmployeeCode != nil {
+		updates = append(updates, fmt.Sprintf("employee_code = $%d", argPos))
+		args = append(args, *req.EmployeeCode)
+		argPos++
+	}
+	if req.Name != nil {
+		updates = append(updates, fmt.Sprintf("name = $%d", argPos))
+		args = append(args, *req.Name)
+		argPos++
+	}
+	if req.Phone != nil {
+		updates = append(updates, fmt.Sprintf("phone = $%d", argPos))
+		args = append(args, *req.Phone)
+		argPos++
+	}
+	if req.Email != nil {
+		updates = append(updates, fmt.Sprintf("email = $%d", argPos))
+		args = append(args, *req.Email)
+		argPos++
+	}
+	if req.Address != nil {
+		updates = append(updates, fmt.Sprintf("address = $%d", argPos))
+		args = append(args, *req.Address)
+		argPos++
+	}
+	if req.Position != nil {
+		updates = append(updates, fmt.Sprintf("position = $%d", argPos))
+		args = append(args, *req.Position)
+		argPos++
+	}
+	if req.Department != nil {
+		updates = append(updates, fmt.Sprintf("department = $%d", argPos))
+		args = append(args, *req.Department)
+		argPos++
+	}
+	if req.Salary != nil {
+		updates = append(updates, fmt.Sprintf("salary = $%d", argPos))
+		args = append(args, *req.Salary)
+		argPos++
+	}
+	if req.HireDate != nil {
+		updates = append(updates, fmt.Sprintf("hire_date = $%d", argPos))
+		args = append(args, *req.HireDate)
+		argPos++
+	}
+	if req.IsActive != nil {
+		updates = append(updates, fmt.Sprintf("is_active = $%d", argPos))
+		args = append(args, *req.IsActive)
+		argPos++
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+	updates = append(updates, fmt.Sprintf("updated_at = $%d", argPos))
+	args = append(args, time.Now())
+	argPos++
+	query := fmt.Sprintf("UPDATE employees SET %s WHERE employee_id = $%d AND company_id = $%d AND is_deleted = FALSE",
+		strings.Join(updates, ", "), argPos, argPos+1)
+	args = append(args, employeeID, companyID)
+	result, err := s.db.Exec(query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to update employee: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("employee not found")
+	}
+	return nil
+}
+
+func (s *EmployeeService) DeleteEmployee(employeeID, companyID int) error {
+	result, err := s.db.Exec(`UPDATE employees SET is_deleted = TRUE, updated_at = CURRENT_TIMESTAMP WHERE employee_id = $1 AND company_id = $2 AND is_deleted = FALSE`, employeeID, companyID)
+	if err != nil {
+		return fmt.Errorf("failed to delete employee: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("employee not found")
+	}
+	return nil
+}

--- a/internal/services/payroll_service.go
+++ b/internal/services/payroll_service.go
@@ -1,0 +1,123 @@
+package services
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"erp-backend/internal/database"
+	"erp-backend/internal/models"
+)
+
+type PayrollService struct {
+	db *sql.DB
+}
+
+func NewPayrollService() *PayrollService {
+	return &PayrollService{db: database.GetDB()}
+}
+
+func (s *PayrollService) GetPayrolls(companyID int, filters map[string]string) ([]models.Payroll, error) {
+	query := `
+                SELECT p.payroll_id, p.employee_id, p.pay_period_start, p.pay_period_end,
+                       p.basic_salary, p.gross_salary, p.total_deductions, p.net_salary,
+                       p.status, p.processed_by, p.sync_status, p.created_at, p.updated_at
+                FROM payroll p
+                JOIN employees e ON p.employee_id = e.employee_id
+                WHERE e.company_id = $1`
+	args := []interface{}{companyID}
+	argPos := 1
+	if empID := filters["employee_id"]; empID != "" {
+		argPos++
+		query += fmt.Sprintf(" AND p.employee_id = $%d", argPos)
+		args = append(args, empID)
+	}
+	if month := filters["month"]; month != "" {
+		start, err := time.Parse("2006-01", month)
+		if err == nil {
+			argPos++
+			query += fmt.Sprintf(" AND p.pay_period_start = $%d", argPos)
+			args = append(args, start)
+		}
+	}
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get payrolls: %w", err)
+	}
+	defer rows.Close()
+
+	var payrolls []models.Payroll
+	for rows.Next() {
+		var p models.Payroll
+		if err := rows.Scan(
+			&p.PayrollID, &p.EmployeeID, &p.PayPeriodStart, &p.PayPeriodEnd,
+			&p.BasicSalary, &p.GrossSalary, &p.TotalDeductions, &p.NetSalary,
+			&p.Status, &p.ProcessedBy, &p.SyncStatus, &p.CreatedAt, &p.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan payroll: %w", err)
+		}
+		payrolls = append(payrolls, p)
+	}
+	return payrolls, nil
+}
+
+func (s *PayrollService) CreatePayroll(companyID int, req *models.CreatePayrollRequest, userID int) (*models.Payroll, error) {
+	var exists bool
+	err := s.db.QueryRow(`SELECT EXISTS(SELECT 1 FROM employees WHERE employee_id = $1 AND company_id = $2 AND is_deleted = FALSE)`, req.EmployeeID, companyID).Scan(&exists)
+	if err != nil {
+		return nil, fmt.Errorf("failed to verify employee: %w", err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("employee not found")
+	}
+	start, err := time.Parse("2006-01", req.Month)
+	if err != nil {
+		return nil, fmt.Errorf("invalid month format")
+	}
+	end := start.AddDate(0, 1, -1)
+	gross := req.BasicSalary + req.Allowances
+	net := gross - req.Deductions
+	query := `
+                INSERT INTO payroll (employee_id, pay_period_start, pay_period_end, basic_salary,
+                                     gross_salary, total_deductions, net_salary, status, processed_by)
+                VALUES ($1,$2,$3,$4,$5,$6,$7,'FINALIZED',$8)
+                RETURNING payroll_id, created_at`
+	var p models.Payroll
+	err = s.db.QueryRow(query,
+		req.EmployeeID, start, end, req.BasicSalary, gross, req.Deductions, net, userID,
+	).Scan(&p.PayrollID, &p.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create payroll: %w", err)
+	}
+	p.EmployeeID = req.EmployeeID
+	p.PayPeriodStart = start
+	p.PayPeriodEnd = end
+	p.BasicSalary = req.BasicSalary
+	p.GrossSalary = gross
+	p.TotalDeductions = req.Deductions
+	p.NetSalary = net
+	p.Status = "FINALIZED"
+	p.ProcessedBy = &userID
+	return &p, nil
+}
+
+func (s *PayrollService) MarkPayrollPaid(payrollID, companyID int) error {
+	result, err := s.db.Exec(`
+                UPDATE payroll p
+                SET status = 'PAID', updated_at = CURRENT_TIMESTAMP
+                FROM employees e
+                WHERE p.payroll_id = $1 AND p.employee_id = e.employee_id AND e.company_id = $2`,
+		payrollID, companyID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to mark payroll paid: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("payroll not found")
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add employee handler, service, and model for basic HR management
- add payroll generation and mark-paid endpoints with service logic
- wire new employee and payroll routes

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e1e15d658832cb307fdc89957c3e5