### PR TITLE
Add sales history and quote endpoints

### DIFF
--- a/internal/models/sales.go
+++ b/internal/models/sales.go
@@ -160,3 +160,56 @@ type SalesSummaryResponse struct {
 		Revenue     float64 `json:"revenue"`
 	} `json:"top_products"`
 }
+
+// Quote represents a sales quote that can be shared with customers before
+// converting to an actual sale. It includes status tracking and basic sharing
+// metadata.
+type Quote struct {
+	QuoteID     int           `json:"quote_id" db:"quote_id"`
+	QuoteNumber string        `json:"quote_number" db:"quote_number"`
+	LocationID  int           `json:"location_id" db:"location_id"`
+	CustomerID  *int          `json:"customer_id,omitempty" db:"customer_id"`
+	QuoteDate   time.Time     `json:"quote_date" db:"quote_date"`
+	TotalAmount float64       `json:"total_amount" db:"total_amount"`
+	Status      string        `json:"status" db:"status"`
+	ShareToken  *string       `json:"share_token,omitempty" db:"share_token"`
+	SharedWith  *string       `json:"shared_with,omitempty" db:"shared_with"`
+	CreatedBy   int           `json:"created_by" db:"created_by"`
+	UpdatedBy   *int          `json:"updated_by,omitempty" db:"updated_by"`
+	Items       []QuoteDetail `json:"items,omitempty"`
+	Customer    *Customer     `json:"customer,omitempty"`
+	SyncModel
+}
+
+// QuoteDetail represents a line item within a quote.
+type QuoteDetail struct {
+	QuoteDetailID   int     `json:"quote_detail_id" db:"quote_detail_id"`
+	QuoteID         int     `json:"quote_id" db:"quote_id"`
+	ProductID       *int    `json:"product_id,omitempty" db:"product_id"`
+	ProductName     *string `json:"product_name,omitempty" db:"product_name"`
+	Quantity        float64 `json:"quantity" db:"quantity"`
+	UnitPrice       float64 `json:"unit_price" db:"unit_price"`
+	DiscountPercent float64 `json:"discount_percentage" db:"discount_percentage"`
+	TaxID           *int    `json:"tax_id,omitempty" db:"tax_id"`
+	TaxAmount       float64 `json:"tax_amount" db:"tax_amount"`
+	LineTotal       float64 `json:"line_total" db:"line_total"`
+}
+
+// CreateQuoteRequest is used when creating a new quote.
+type CreateQuoteRequest struct {
+	CustomerID *int                      `json:"customer_id,omitempty"`
+	Items      []CreateSaleDetailRequest `json:"items" validate:"required,min=1"`
+	Notes      *string                   `json:"notes,omitempty"`
+}
+
+// UpdateQuoteRequest is used for updating existing quotes.
+type UpdateQuoteRequest struct {
+	Status *string `json:"status,omitempty"`
+	Notes  *string `json:"notes,omitempty"`
+}
+
+// ShareQuoteRequest carries information needed to share a quote with a
+// customer. The email is stored for reference when generating share links.
+type ShareQuoteRequest struct {
+	Email string `json:"email" validate:"required,email"`
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -189,6 +189,8 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 			sales.Use(middleware.RequireCompanyAccess())
 			{
 				sales.GET("", middleware.RequirePermission("VIEW_SALES"), salesHandler.GetSales)
+				sales.GET("/history", middleware.RequirePermission("VIEW_SALES"), salesHandler.GetSalesHistory)
+				sales.GET("/history/export", middleware.RequirePermission("VIEW_SALES"), salesHandler.ExportInvoices)
 				sales.GET("/:id", middleware.RequirePermission("VIEW_SALES"), salesHandler.GetSale)
 				sales.POST("", middleware.RequirePermission("CREATE_SALES"), salesHandler.CreateSale)
 				sales.PUT("/:id", middleware.RequirePermission("UPDATE_SALES"), salesHandler.UpdateSale)
@@ -196,6 +198,18 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 				sales.POST("/:id/hold", middleware.RequirePermission("CREATE_SALES"), salesHandler.HoldSale)
 				sales.POST("/:id/resume", middleware.RequirePermission("CREATE_SALES"), salesHandler.ResumeSale)
 				sales.POST("/quick", middleware.RequirePermission("CREATE_SALES"), salesHandler.CreateQuickSale)
+
+				quotes := sales.Group("/quotes")
+				{
+					quotes.GET("", middleware.RequirePermission("VIEW_SALES"), salesHandler.GetQuotes)
+					quotes.GET("/export", middleware.RequirePermission("VIEW_SALES"), salesHandler.ExportQuotes)
+					quotes.GET("/:id", middleware.RequirePermission("VIEW_SALES"), salesHandler.GetQuote)
+					quotes.POST("", middleware.RequirePermission("CREATE_SALES"), salesHandler.CreateQuote)
+					quotes.PUT("/:id", middleware.RequirePermission("UPDATE_SALES"), salesHandler.UpdateQuote)
+					quotes.DELETE("/:id", middleware.RequirePermission("DELETE_SALES"), salesHandler.DeleteQuote)
+					quotes.POST("/:id/print", middleware.RequirePermission("PRINT_INVOICES"), salesHandler.PrintQuote)
+					quotes.POST("/:id/share", middleware.RequirePermission("VIEW_SALES"), salesHandler.ShareQuote)
+				}
 			}
 
 			// POS specific routes (require company and location)


### PR DESCRIPTION
## Summary
- add quote models with status and sharing metadata
- support sales history and invoice export
- introduce sales quote CRUD, print, share, and export endpoints

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e272262c0832c89896652ec1c6cac