### PR TITLE
feat: add settings sub-routes and CRUD

### DIFF
--- a/internal/handlers/settings.go
+++ b/internal/handlers/settings.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"strconv"
 
 	"erp-backend/internal/models"
 	"erp-backend/internal/services"
@@ -60,4 +61,302 @@ func (h *SettingsHandler) UpdateSettings(c *gin.Context) {
 	}
 
 	utils.SuccessResponse(c, "Settings updated successfully", nil)
+}
+
+// Company settings
+func (h *SettingsHandler) GetCompanySettings(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	settings, err := h.service.GetCompanySettings(companyID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get company settings", err)
+		return
+	}
+	utils.SuccessResponse(c, "Company settings retrieved successfully", settings)
+}
+
+func (h *SettingsHandler) UpdateCompanySettings(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	var req models.CompanySettings
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	if err := h.service.UpdateCompanySettings(companyID, req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to update company settings", err)
+		return
+	}
+	utils.SuccessResponse(c, "Company settings updated successfully", nil)
+}
+
+// Invoice settings
+func (h *SettingsHandler) GetInvoiceSettings(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	settings, err := h.service.GetInvoiceSettings(companyID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get invoice settings", err)
+		return
+	}
+	utils.SuccessResponse(c, "Invoice settings retrieved successfully", settings)
+}
+
+func (h *SettingsHandler) UpdateInvoiceSettings(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	var req models.InvoiceSettings
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	if err := h.service.UpdateInvoiceSettings(companyID, req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to update invoice settings", err)
+		return
+	}
+	utils.SuccessResponse(c, "Invoice settings updated successfully", nil)
+}
+
+// Tax settings
+func (h *SettingsHandler) GetTaxSettings(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	settings, err := h.service.GetTaxSettings(companyID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get tax settings", err)
+		return
+	}
+	utils.SuccessResponse(c, "Tax settings retrieved successfully", settings)
+}
+
+func (h *SettingsHandler) UpdateTaxSettings(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	var req models.TaxSettings
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	if err := h.service.UpdateTaxSettings(companyID, req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to update tax settings", err)
+		return
+	}
+	utils.SuccessResponse(c, "Tax settings updated successfully", nil)
+}
+
+// Device control settings
+func (h *SettingsHandler) GetDeviceControlSettings(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	settings, err := h.service.GetDeviceControlSettings(companyID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get device control settings", err)
+		return
+	}
+	utils.SuccessResponse(c, "Device control settings retrieved successfully", settings)
+}
+
+func (h *SettingsHandler) UpdateDeviceControlSettings(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	var req models.DeviceControlSettings
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	if err := h.service.UpdateDeviceControlSettings(companyID, req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to update device control settings", err)
+		return
+	}
+	utils.SuccessResponse(c, "Device control settings updated successfully", nil)
+}
+
+// Payment methods CRUD
+func (h *SettingsHandler) GetPaymentMethods(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	methods, err := h.service.GetPaymentMethods(companyID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get payment methods", err)
+		return
+	}
+	utils.SuccessResponse(c, "Payment methods retrieved successfully", methods)
+}
+
+func (h *SettingsHandler) CreatePaymentMethod(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	var req models.PaymentMethodRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	if err := utils.ValidateStruct(&req); err != nil {
+		utils.ValidationErrorResponse(c, utils.GetValidationErrors(err))
+		return
+	}
+	pm, err := h.service.CreatePaymentMethod(companyID, &req)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to create payment method", err)
+		return
+	}
+	utils.CreatedResponse(c, "Payment method created successfully", pm)
+}
+
+func (h *SettingsHandler) UpdatePaymentMethod(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid payment method ID", err)
+		return
+	}
+	var req models.PaymentMethodRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	if err := utils.ValidateStruct(&req); err != nil {
+		utils.ValidationErrorResponse(c, utils.GetValidationErrors(err))
+		return
+	}
+	if err := h.service.UpdatePaymentMethod(companyID, id, &req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to update payment method", err)
+		return
+	}
+	utils.SuccessResponse(c, "Payment method updated successfully", nil)
+}
+
+func (h *SettingsHandler) DeletePaymentMethod(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid payment method ID", err)
+		return
+	}
+	if err := h.service.DeletePaymentMethod(companyID, id); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to delete payment method", err)
+		return
+	}
+	utils.SuccessResponse(c, "Payment method deleted successfully", nil)
+}
+
+// Printer profiles CRUD
+func (h *SettingsHandler) GetPrinters(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	printers, err := h.service.GetPrinters(companyID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get printers", err)
+		return
+	}
+	utils.SuccessResponse(c, "Printers retrieved successfully", printers)
+}
+
+func (h *SettingsHandler) CreatePrinter(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	var req models.PrinterProfile
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	if err := utils.ValidateStruct(&req); err != nil {
+		utils.ValidationErrorResponse(c, utils.GetValidationErrors(err))
+		return
+	}
+	printer, err := h.service.CreatePrinter(companyID, &req)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to create printer", err)
+		return
+	}
+	utils.CreatedResponse(c, "Printer created successfully", printer)
+}
+
+func (h *SettingsHandler) UpdatePrinter(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid printer ID", err)
+		return
+	}
+	var req models.PrinterProfile
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	if err := utils.ValidateStruct(&req); err != nil {
+		utils.ValidationErrorResponse(c, utils.GetValidationErrors(err))
+		return
+	}
+	if err := h.service.UpdatePrinter(companyID, id, &req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to update printer", err)
+		return
+	}
+	utils.SuccessResponse(c, "Printer updated successfully", nil)
+}
+
+func (h *SettingsHandler) DeletePrinter(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid printer ID", err)
+		return
+	}
+	if err := h.service.DeletePrinter(companyID, id); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to delete printer", err)
+		return
+	}
+	utils.SuccessResponse(c, "Printer deleted successfully", nil)
 }

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -9,7 +9,7 @@ type Setting struct {
 	CompanyID   int       `json:"company_id" db:"company_id"`
 	LocationID  *int      `json:"location_id,omitempty" db:"location_id"`
 	Key         string    `json:"key" db:"key"`
-	Value       string    `json:"value" db:"value"`
+	Value       JSONB     `json:"value" db:"value"`
 	Description *string   `json:"description,omitempty" db:"description"`
 	DataType    string    `json:"data_type" db:"data_type"`
 	CreatedAt   time.Time `json:"created_at" db:"created_at"`
@@ -20,5 +20,52 @@ type Setting struct {
 // The map key represents the setting key and value represents the setting value
 // Example: {"currency":"INR"}
 type UpdateSettingsRequest struct {
-	Settings map[string]string `json:"settings" validate:"required"`
+	Settings map[string]JSONB `json:"settings" validate:"required"`
+}
+
+// CompanySettings holds company-related configuration
+type CompanySettings struct {
+	Name    string  `json:"name,omitempty"`
+	Address *string `json:"address,omitempty"`
+	Phone   *string `json:"phone,omitempty"`
+	Email   *string `json:"email,omitempty"`
+}
+
+// InvoiceSettings holds invoice-related configuration
+type InvoiceSettings struct {
+	Prefix     *string `json:"prefix,omitempty"`
+	NextNumber *int    `json:"next_number,omitempty"`
+	Notes      *string `json:"notes,omitempty"`
+}
+
+// TaxSettings holds tax-related configuration
+type TaxSettings struct {
+	TaxName    *string  `json:"tax_name,omitempty"`
+	TaxPercent *float64 `json:"tax_percent,omitempty"`
+}
+
+// DeviceControlSettings holds device control related configuration
+type DeviceControlSettings struct {
+	AllowRemote bool `json:"allow_remote"`
+}
+
+// PrinterProfile represents a printer configuration profile
+type PrinterProfile struct {
+	PrinterID    int     `json:"printer_id" db:"printer_id"`
+	CompanyID    int     `json:"company_id" db:"company_id"`
+	LocationID   *int    `json:"location_id,omitempty" db:"location_id"`
+	Name         string  `json:"name" db:"name" validate:"required"`
+	PrinterType  string  `json:"printer_type" db:"printer_type" validate:"required"`
+	PaperSize    *string `json:"paper_size,omitempty" db:"paper_size"`
+	Connectivity *JSONB  `json:"connectivity,omitempty" db:"connectivity"`
+	IsDefault    bool    `json:"is_default" db:"is_default"`
+	IsActive     bool    `json:"is_active" db:"is_active"`
+}
+
+// PaymentMethodRequest is used to create or update payment methods
+type PaymentMethodRequest struct {
+	Name                string `json:"name" validate:"required"`
+	Type                string `json:"type" validate:"required"`
+	ExternalIntegration *JSONB `json:"external_integration,omitempty"`
+	IsActive            bool   `json:"is_active"`
 }

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -355,6 +355,28 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 			{
 				settings.GET("", middleware.RequirePermission("VIEW_SETTINGS"), settingsHandler.GetSettings)
 				settings.PUT("", middleware.RequirePermission("MANAGE_SETTINGS"), settingsHandler.UpdateSettings)
+
+				settings.GET("/company", middleware.RequirePermission("VIEW_SETTINGS"), settingsHandler.GetCompanySettings)
+				settings.PUT("/company", middleware.RequirePermission("MANAGE_SETTINGS"), settingsHandler.UpdateCompanySettings)
+
+				settings.GET("/invoice", middleware.RequirePermission("VIEW_SETTINGS"), settingsHandler.GetInvoiceSettings)
+				settings.PUT("/invoice", middleware.RequirePermission("MANAGE_SETTINGS"), settingsHandler.UpdateInvoiceSettings)
+
+				settings.GET("/tax", middleware.RequirePermission("VIEW_SETTINGS"), settingsHandler.GetTaxSettings)
+				settings.PUT("/tax", middleware.RequirePermission("MANAGE_SETTINGS"), settingsHandler.UpdateTaxSettings)
+
+				settings.GET("/device-control", middleware.RequirePermission("VIEW_SETTINGS"), settingsHandler.GetDeviceControlSettings)
+				settings.PUT("/device-control", middleware.RequirePermission("MANAGE_SETTINGS"), settingsHandler.UpdateDeviceControlSettings)
+
+				settings.GET("/payment-methods", middleware.RequirePermission("VIEW_SETTINGS"), settingsHandler.GetPaymentMethods)
+				settings.POST("/payment-methods", middleware.RequirePermission("MANAGE_SETTINGS"), settingsHandler.CreatePaymentMethod)
+				settings.PUT("/payment-methods/:id", middleware.RequirePermission("MANAGE_SETTINGS"), settingsHandler.UpdatePaymentMethod)
+				settings.DELETE("/payment-methods/:id", middleware.RequirePermission("MANAGE_SETTINGS"), settingsHandler.DeletePaymentMethod)
+
+				settings.GET("/printer", middleware.RequirePermission("VIEW_SETTINGS"), settingsHandler.GetPrinters)
+				settings.POST("/printer", middleware.RequirePermission("MANAGE_SETTINGS"), settingsHandler.CreatePrinter)
+				settings.PUT("/printer/:id", middleware.RequirePermission("MANAGE_SETTINGS"), settingsHandler.UpdatePrinter)
+				settings.DELETE("/printer/:id", middleware.RequirePermission("MANAGE_SETTINGS"), settingsHandler.DeletePrinter)
 			}
 
 			// Audit log routes

--- a/internal/services/settings_service.go
+++ b/internal/services/settings_service.go
@@ -2,9 +2,11 @@ package services
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 
 	"erp-backend/internal/database"
+	"erp-backend/internal/models"
 )
 
 // SettingsService provides methods to manage system settings
@@ -21,7 +23,7 @@ func NewSettingsService() *SettingsService {
 }
 
 // GetSettings retrieves all settings for a company
-func (s *SettingsService) GetSettings(companyID int) (map[string]string, error) {
+func (s *SettingsService) GetSettings(companyID int) (map[string]models.JSONB, error) {
 	query := `SELECT key, value FROM settings WHERE company_id = $1`
 	rows, err := s.db.Query(query, companyID)
 	if err != nil {
@@ -29,9 +31,10 @@ func (s *SettingsService) GetSettings(companyID int) (map[string]string, error) 
 	}
 	defer rows.Close()
 
-	settings := make(map[string]string)
+	settings := make(map[string]models.JSONB)
 	for rows.Next() {
-		var key, value string
+		var key string
+		var value models.JSONB
 		if err := rows.Scan(&key, &value); err != nil {
 			return nil, fmt.Errorf("failed to scan setting: %w", err)
 		}
@@ -42,7 +45,7 @@ func (s *SettingsService) GetSettings(companyID int) (map[string]string, error) 
 }
 
 // UpdateSettings updates or inserts multiple settings for a company
-func (s *SettingsService) UpdateSettings(companyID int, settings map[string]string) error {
+func (s *SettingsService) UpdateSettings(companyID int, settings map[string]models.JSONB) error {
 	tx, err := s.db.Begin()
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
@@ -64,6 +67,186 @@ func (s *SettingsService) UpdateSettings(companyID int, settings map[string]stri
 
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("failed to commit settings: %w", err)
+	}
+	return nil
+}
+
+func (s *SettingsService) getJSONSetting(companyID int, key string, dest interface{}) error {
+	var value models.JSONB
+	err := s.db.QueryRow(`SELECT value FROM settings WHERE company_id=$1 AND key=$2`, companyID, key).Scan(&value)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get %s settings: %w", key, err)
+	}
+	b, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s settings: %w", key, err)
+	}
+	if err := json.Unmarshal(b, dest); err != nil {
+		return fmt.Errorf("failed to unmarshal %s settings: %w", key, err)
+	}
+	return nil
+}
+
+func (s *SettingsService) updateJSONSetting(companyID int, key string, cfg interface{}) error {
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %s settings: %w", key, err)
+	}
+	var value models.JSONB
+	if err := json.Unmarshal(b, &value); err != nil {
+		return fmt.Errorf("failed to unmarshal %s settings: %w", key, err)
+	}
+	return s.UpdateSettings(companyID, map[string]models.JSONB{key: value})
+}
+
+// Company settings
+func (s *SettingsService) GetCompanySettings(companyID int) (*models.CompanySettings, error) {
+	var cfg models.CompanySettings
+	if err := s.getJSONSetting(companyID, "company", &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func (s *SettingsService) UpdateCompanySettings(companyID int, cfg models.CompanySettings) error {
+	return s.updateJSONSetting(companyID, "company", cfg)
+}
+
+// Invoice settings
+func (s *SettingsService) GetInvoiceSettings(companyID int) (*models.InvoiceSettings, error) {
+	var cfg models.InvoiceSettings
+	if err := s.getJSONSetting(companyID, "invoice", &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func (s *SettingsService) UpdateInvoiceSettings(companyID int, cfg models.InvoiceSettings) error {
+	return s.updateJSONSetting(companyID, "invoice", cfg)
+}
+
+// Tax settings
+func (s *SettingsService) GetTaxSettings(companyID int) (*models.TaxSettings, error) {
+	var cfg models.TaxSettings
+	if err := s.getJSONSetting(companyID, "tax", &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func (s *SettingsService) UpdateTaxSettings(companyID int, cfg models.TaxSettings) error {
+	return s.updateJSONSetting(companyID, "tax", cfg)
+}
+
+// Device control settings
+func (s *SettingsService) GetDeviceControlSettings(companyID int) (*models.DeviceControlSettings, error) {
+	var cfg models.DeviceControlSettings
+	if err := s.getJSONSetting(companyID, "device_control", &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func (s *SettingsService) UpdateDeviceControlSettings(companyID int, cfg models.DeviceControlSettings) error {
+	return s.updateJSONSetting(companyID, "device_control", cfg)
+}
+
+// Payment methods CRUD
+func (s *SettingsService) GetPaymentMethods(companyID int) ([]models.PaymentMethod, error) {
+	rows, err := s.db.Query(`SELECT method_id, company_id, name, type, external_integration, is_active FROM payment_methods WHERE company_id=$1`, companyID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get payment methods: %w", err)
+	}
+	defer rows.Close()
+
+	var methods []models.PaymentMethod
+	for rows.Next() {
+		var m models.PaymentMethod
+		var ext models.JSONB
+		var cid int
+		if err := rows.Scan(&m.MethodID, &cid, &m.Name, &m.Type, &ext, &m.IsActive); err != nil {
+			return nil, fmt.Errorf("failed to scan payment method: %w", err)
+		}
+		m.CompanyID = &cid
+		m.ExternalIntegration = &ext
+		methods = append(methods, m)
+	}
+	return methods, nil
+}
+
+func (s *SettingsService) CreatePaymentMethod(companyID int, req *models.PaymentMethodRequest) (*models.PaymentMethod, error) {
+	row := s.db.QueryRow(`INSERT INTO payment_methods (company_id, name, type, external_integration, is_active) VALUES ($1,$2,$3,$4,$5) RETURNING method_id, name, type, external_integration, is_active`, companyID, req.Name, req.Type, req.ExternalIntegration, req.IsActive)
+	var pm models.PaymentMethod
+	var ext models.JSONB
+	if err := row.Scan(&pm.MethodID, &pm.Name, &pm.Type, &ext, &pm.IsActive); err != nil {
+		return nil, fmt.Errorf("failed to create payment method: %w", err)
+	}
+	pm.CompanyID = &companyID
+	pm.ExternalIntegration = &ext
+	return &pm, nil
+}
+
+func (s *SettingsService) UpdatePaymentMethod(companyID, id int, req *models.PaymentMethodRequest) error {
+	_, err := s.db.Exec(`UPDATE payment_methods SET name=$1, type=$2, external_integration=$3, is_active=$4 WHERE method_id=$5 AND company_id=$6`, req.Name, req.Type, req.ExternalIntegration, req.IsActive, id, companyID)
+	if err != nil {
+		return fmt.Errorf("failed to update payment method: %w", err)
+	}
+	return nil
+}
+
+func (s *SettingsService) DeletePaymentMethod(companyID, id int) error {
+	_, err := s.db.Exec(`DELETE FROM payment_methods WHERE method_id=$1 AND company_id=$2`, id, companyID)
+	if err != nil {
+		return fmt.Errorf("failed to delete payment method: %w", err)
+	}
+	return nil
+}
+
+// Printer profiles CRUD
+func (s *SettingsService) GetPrinters(companyID int) ([]models.PrinterProfile, error) {
+	rows, err := s.db.Query(`SELECT printer_id, company_id, location_id, name, printer_type, paper_size, connectivity, is_default, is_active FROM printer_settings WHERE company_id=$1`, companyID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get printers: %w", err)
+	}
+	defer rows.Close()
+
+	var printers []models.PrinterProfile
+	for rows.Next() {
+		var p models.PrinterProfile
+		var conn models.JSONB
+		if err := rows.Scan(&p.PrinterID, &p.CompanyID, &p.LocationID, &p.Name, &p.PrinterType, &p.PaperSize, &conn, &p.IsDefault, &p.IsActive); err != nil {
+			return nil, fmt.Errorf("failed to scan printer: %w", err)
+		}
+		p.Connectivity = &conn
+		printers = append(printers, p)
+	}
+	return printers, nil
+}
+
+func (s *SettingsService) CreatePrinter(companyID int, req *models.PrinterProfile) (*models.PrinterProfile, error) {
+	row := s.db.QueryRow(`INSERT INTO printer_settings (company_id, location_id, name, printer_type, paper_size, connectivity, is_default, is_active) VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING printer_id`, companyID, req.LocationID, req.Name, req.PrinterType, req.PaperSize, req.Connectivity, req.IsDefault, req.IsActive)
+	if err := row.Scan(&req.PrinterID); err != nil {
+		return nil, fmt.Errorf("failed to create printer: %w", err)
+	}
+	req.CompanyID = companyID
+	return req, nil
+}
+
+func (s *SettingsService) UpdatePrinter(companyID, id int, req *models.PrinterProfile) error {
+	_, err := s.db.Exec(`UPDATE printer_settings SET location_id=$1, name=$2, printer_type=$3, paper_size=$4, connectivity=$5, is_default=$6, is_active=$7 WHERE printer_id=$8 AND company_id=$9`, req.LocationID, req.Name, req.PrinterType, req.PaperSize, req.Connectivity, req.IsDefault, req.IsActive, id, companyID)
+	if err != nil {
+		return fmt.Errorf("failed to update printer: %w", err)
+	}
+	return nil
+}
+
+func (s *SettingsService) DeletePrinter(companyID, id int) error {
+	_, err := s.db.Exec(`DELETE FROM printer_settings WHERE printer_id=$1 AND company_id=$2`, id, companyID)
+	if err != nil {
+		return fmt.Errorf("failed to delete printer: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- extend settings model for structured JSON sub-configs and printer profiles
- add company, invoice, tax, device-control, payment method, and printer endpoints with handlers
- implement service methods for storing JSON settings and CRUD for payment methods and printers

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e27419e40832cb6ff9f08e54540d5