### PR TITLE
Add quotes schema, models, and permissions

### DIFF
--- a/Docs & Schema/PostgrSQL.sql
+++ b/Docs & Schema/PostgrSQL.sql
@@ -378,6 +378,45 @@ CREATE TABLE sale_return_details (
     line_total NUMERIC(12,2) NOT NULL
 );
 
+-- Quotes Table
+CREATE TABLE quotes (
+    quote_id SERIAL PRIMARY KEY,
+    quote_number VARCHAR(100) NOT NULL,
+    location_id INTEGER NOT NULL REFERENCES locations(location_id),
+    customer_id INTEGER REFERENCES customers(customer_id),
+    quote_date DATE NOT NULL DEFAULT CURRENT_DATE,
+    valid_until DATE,
+    subtotal NUMERIC(12,2) NOT NULL DEFAULT 0,
+    tax_amount NUMERIC(12,2) DEFAULT 0,
+    discount_amount NUMERIC(12,2) DEFAULT 0,
+    total_amount NUMERIC(12,2) NOT NULL DEFAULT 0,
+    status VARCHAR(50) DEFAULT 'DRAFT' CHECK (status IN ('DRAFT','SENT','ACCEPTED')),
+    notes TEXT,
+    created_by INTEGER NOT NULL REFERENCES users(user_id),
+    updated_by INTEGER REFERENCES users(user_id),
+    sync_status VARCHAR(20) DEFAULT 'synced',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    is_deleted BOOLEAN DEFAULT FALSE
+);
+
+-- Quote Items Table
+CREATE TABLE quote_items (
+    quote_item_id SERIAL PRIMARY KEY,
+    quote_id INTEGER NOT NULL REFERENCES quotes(quote_id) ON DELETE CASCADE,
+    product_id INTEGER REFERENCES products(product_id),
+    product_name VARCHAR(255),
+    quantity NUMERIC(10,3) NOT NULL,
+    unit_price NUMERIC(12,2) NOT NULL,
+    discount_percentage NUMERIC(5,2) DEFAULT 0,
+    discount_amount NUMERIC(12,2) DEFAULT 0,
+    tax_id INTEGER REFERENCES taxes(tax_id),
+    tax_amount NUMERIC(12,2) DEFAULT 0,
+    line_total NUMERIC(12,2) NOT NULL,
+    serial_numbers TEXT[],
+    notes TEXT
+);
+
 -- Purchases Table
 CREATE TABLE purchases (
     purchase_id SERIAL PRIMARY KEY,
@@ -844,6 +883,11 @@ CREATE INDEX idx_sales_created_by ON sales(created_by);
 CREATE INDEX idx_sale_details_sale ON sale_details(sale_id);
 CREATE INDEX idx_sale_details_product ON sale_details(product_id);
 
+-- Quotes
+CREATE INDEX idx_quotes_customer ON quotes(customer_id);
+CREATE INDEX idx_quotes_date ON quotes(quote_date);
+CREATE INDEX idx_quotes_status ON quotes(status);
+
 -- Purchases
 CREATE INDEX idx_purchases_location ON purchases(location_id);
 CREATE INDEX idx_purchases_supplier ON purchases(supplier_id);
@@ -912,6 +956,7 @@ CREATE TRIGGER update_users_updated_at BEFORE UPDATE ON users FOR EACH ROW EXECU
 CREATE TRIGGER update_products_updated_at BEFORE UPDATE ON products FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER update_customers_updated_at BEFORE UPDATE ON customers FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER update_suppliers_updated_at BEFORE UPDATE ON suppliers FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_quotes_updated_at BEFORE UPDATE ON quotes FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER update_sales_updated_at BEFORE UPDATE ON sales FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER update_purchases_updated_at BEFORE UPDATE ON purchases FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
@@ -979,6 +1024,7 @@ ALTER TABLE locations ENABLE ROW LEVEL SECURITY;
 ALTER TABLE users ENABLE ROW LEVEL SECURITY;
 ALTER TABLE products ENABLE ROW LEVEL SECURITY;
 ALTER TABLE sales ENABLE ROW LEVEL SECURITY;
+ALTER TABLE quotes ENABLE ROW LEVEL SECURITY;
 ALTER TABLE purchases ENABLE ROW LEVEL SECURITY;
 
 -- Example RLS Policies (customize based on your auth system)
@@ -1176,6 +1222,10 @@ INSERT INTO permissions (name, description, module, action) VALUES
 ('UPDATE_SALES', 'Update existing sales records', 'sales', 'update'),
 ('DELETE_SALES', 'Delete or void sales records', 'sales', 'delete'),
 ('CREATE_RETURNS', 'Process sale returns', 'sales', 'return'),
+('VIEW_QUOTES', 'View quotes and proposals', 'quotes', 'view'),
+('CREATE_QUOTES', 'Create new quotes', 'quotes', 'create'),
+('UPDATE_QUOTES', 'Update existing quotes', 'quotes', 'update'),
+('DELETE_QUOTES', 'Delete quotes', 'quotes', 'delete'),
 
 -- POS permissions
 ('PRINT_INVOICES', 'Print invoices and receipts', 'pos', 'print'),
@@ -1205,7 +1255,8 @@ INSERT INTO role_permissions (role_id, permission_id)
 SELECT 2, permission_id FROM permissions 
 WHERE name IN (
     'VIEW_SALES', 'CREATE_SALES', 'UPDATE_SALES', 'CREATE_RETURNS',
-    'PRINT_INVOICES', 'VIEW_REPORTS', 'VIEW_CUSTOMERS', 'CREATE_CUSTOMERS', 
+    'VIEW_QUOTES', 'CREATE_QUOTES', 'UPDATE_QUOTES',
+    'PRINT_INVOICES', 'VIEW_REPORTS', 'VIEW_CUSTOMERS', 'CREATE_CUSTOMERS',
     'UPDATE_CUSTOMERS'
 )
 ON CONFLICT (role_id, permission_id) DO NOTHING;
@@ -1215,6 +1266,7 @@ INSERT INTO role_permissions (role_id, permission_id)
 SELECT 4, permission_id FROM permissions 
 WHERE name IN (
     'VIEW_SALES', 'CREATE_SALES', 'CREATE_RETURNS', 'PRINT_INVOICES',
+    'VIEW_QUOTES', 'CREATE_QUOTES', 'UPDATE_QUOTES',
     'VIEW_CUSTOMERS', 'CREATE_CUSTOMERS', 'UPDATE_CUSTOMERS'
 )
 ON CONFLICT (role_id, permission_id) DO NOTHING;
@@ -1223,7 +1275,8 @@ ON CONFLICT (role_id, permission_id) DO NOTHING;
 INSERT INTO role_permissions (role_id, permission_id)
 SELECT 5, permission_id FROM permissions 
 WHERE name IN (
-    'VIEW_SALES', 'CREATE_SALES', 'PRINT_INVOICES', 'VIEW_CUSTOMERS'
+    'VIEW_SALES', 'CREATE_SALES', 'PRINT_INVOICES', 'VIEW_CUSTOMERS',
+    'VIEW_QUOTES', 'CREATE_QUOTES'
 )
 ON CONFLICT (role_id, permission_id) DO NOTHING;
 
@@ -1234,6 +1287,8 @@ CREATE INDEX IF NOT EXISTS idx_sales_location_date ON sales(location_id, sale_da
 CREATE INDEX IF NOT EXISTS idx_sales_customer_date ON sales(customer_id, sale_date);
 CREATE INDEX IF NOT EXISTS idx_sales_status ON sales(status);
 CREATE INDEX IF NOT EXISTS idx_sales_pos_status ON sales(pos_status);
+CREATE INDEX IF NOT EXISTS idx_quotes_customer_date ON quotes(customer_id, quote_date);
+CREATE INDEX IF NOT EXISTS idx_quotes_status ON quotes(status);
 CREATE INDEX IF NOT EXISTS idx_sale_details_product ON sale_details(product_id);
 CREATE INDEX IF NOT EXISTS idx_payment_methods_company ON payment_methods(company_id);
 

--- a/internal/models/quote.go
+++ b/internal/models/quote.go
@@ -1,0 +1,65 @@
+package models
+
+import "time"
+
+type Quote struct {
+	QuoteID        int         `json:"quote_id" db:"quote_id"`
+	QuoteNumber    string      `json:"quote_number" db:"quote_number"`
+	LocationID     int         `json:"location_id" db:"location_id"`
+	CustomerID     *int        `json:"customer_id,omitempty" db:"customer_id"`
+	QuoteDate      time.Time   `json:"quote_date" db:"quote_date"`
+	ValidUntil     *time.Time  `json:"valid_until,omitempty" db:"valid_until"`
+	Subtotal       float64     `json:"subtotal" db:"subtotal"`
+	TaxAmount      float64     `json:"tax_amount" db:"tax_amount"`
+	DiscountAmount float64     `json:"discount_amount" db:"discount_amount"`
+	TotalAmount    float64     `json:"total_amount" db:"total_amount"`
+	Status         string      `json:"status" db:"status"`
+	Notes          *string     `json:"notes,omitempty" db:"notes"`
+	CreatedBy      int         `json:"created_by" db:"created_by"`
+	UpdatedBy      *int        `json:"updated_by,omitempty" db:"updated_by"`
+	Items          []QuoteItem `json:"items,omitempty"`
+	Customer       *Customer   `json:"customer,omitempty"`
+	SyncModel
+}
+
+type QuoteItem struct {
+	QuoteItemID     int      `json:"quote_item_id" db:"quote_item_id"`
+	QuoteID         int      `json:"quote_id" db:"quote_id"`
+	ProductID       *int     `json:"product_id,omitempty" db:"product_id"`
+	ProductName     *string  `json:"product_name,omitempty" db:"product_name"`
+	Quantity        float64  `json:"quantity" db:"quantity"`
+	UnitPrice       float64  `json:"unit_price" db:"unit_price"`
+	DiscountPercent float64  `json:"discount_percentage" db:"discount_percentage"`
+	DiscountAmount  float64  `json:"discount_amount" db:"discount_amount"`
+	TaxID           *int     `json:"tax_id,omitempty" db:"tax_id"`
+	TaxAmount       float64  `json:"tax_amount" db:"tax_amount"`
+	LineTotal       float64  `json:"line_total" db:"line_total"`
+	SerialNumbers   []string `json:"serial_numbers,omitempty" db:"serial_numbers"`
+	Notes           *string  `json:"notes,omitempty" db:"notes"`
+	Product         *Product `json:"product,omitempty"`
+}
+
+type CreateQuoteRequest struct {
+	CustomerID     *int                     `json:"customer_id,omitempty"`
+	Items          []CreateQuoteItemRequest `json:"items" validate:"required,min=1"`
+	DiscountAmount float64                  `json:"discount_amount"`
+	ValidUntil     time.Time                `json:"valid_until"`
+	Notes          *string                  `json:"notes,omitempty"`
+}
+
+type CreateQuoteItemRequest struct {
+	ProductID       *int     `json:"product_id,omitempty"`
+	ProductName     *string  `json:"product_name,omitempty"`
+	Quantity        float64  `json:"quantity" validate:"required,gt=0"`
+	UnitPrice       float64  `json:"unit_price" validate:"required,gt=0"`
+	DiscountPercent float64  `json:"discount_percentage"`
+	TaxID           *int     `json:"tax_id,omitempty"`
+	SerialNumbers   []string `json:"serial_numbers,omitempty"`
+	Notes           *string  `json:"notes,omitempty"`
+}
+
+type UpdateQuoteRequest struct {
+	Status     *string    `json:"status,omitempty"`
+	Notes      *string    `json:"notes,omitempty"`
+	ValidUntil *time.Time `json:"valid_until,omitempty"`
+}


### PR DESCRIPTION
## Summary
- add quotes and quote_items tables with status and validity fields
- index quotes on customer, date, and status
- introduce quote models and permissions with role assignments

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e2745feb4832cae9abb558afc70fa