### PR TITLE
feat: add invoice numbering configuration tables

### DIFF
--- a/Docs & Schema/PostgrSQL.sql
+++ b/Docs & Schema/PostgrSQL.sql
@@ -756,6 +756,31 @@ CREATE TABLE printer_settings (
     is_active BOOLEAN DEFAULT TRUE
 );
 
+-- Numbering Sequences Table
+CREATE TABLE numbering_sequences (
+    sequence_id SERIAL PRIMARY KEY,
+    company_id INTEGER NOT NULL REFERENCES companies(company_id) ON DELETE CASCADE,
+    location_id INTEGER REFERENCES locations(location_id),
+    name VARCHAR(100) NOT NULL,
+    prefix VARCHAR(20),
+    sequence_length INTEGER NOT NULL DEFAULT 6,
+    current_number INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Invoice Formats Table
+CREATE TABLE invoice_formats (
+    format_id SERIAL PRIMARY KEY,
+    company_id INTEGER NOT NULL REFERENCES companies(company_id) ON DELETE CASCADE,
+    location_id INTEGER REFERENCES locations(location_id),
+    sequence_id INTEGER REFERENCES numbering_sequences(sequence_id),
+    name VARCHAR(100) NOT NULL,
+    tax_fields JSONB,
+    is_default BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
 -- Invoice Templates Table
 CREATE TABLE invoice_templates (
     template_id SERIAL PRIMARY KEY,
@@ -892,6 +917,8 @@ CREATE INDEX idx_audit_log_timestamp ON audit_log(timestamp);
 -- Settings and Configuration
 CREATE INDEX idx_settings_company_key ON settings(company_id, key);
 CREATE INDEX idx_translations_key_lang ON translations(key, language_code);
+CREATE INDEX idx_invoice_formats_company_location ON invoice_formats(company_id, location_id);
+CREATE INDEX idx_numbering_sequences_company_location ON numbering_sequences(company_id, location_id);
 
 -- ===============================================
 -- TRIGGERS FOR UPDATED_AT TIMESTAMPS

--- a/internal/models/invoice_format.go
+++ b/internal/models/invoice_format.go
@@ -1,0 +1,32 @@
+package models
+
+// InvoiceFormat holds formatting and tax configuration for invoices
+// at the company/location level.
+type InvoiceFormat struct {
+	FormatID   int    `json:"format_id" db:"format_id"`
+	CompanyID  int    `json:"company_id" db:"company_id" validate:"required"`
+	LocationID *int   `json:"location_id,omitempty" db:"location_id"`
+	SequenceID *int   `json:"sequence_id,omitempty" db:"sequence_id"`
+	Name       string `json:"name" db:"name" validate:"required"`
+	TaxFields  JSONB  `json:"tax_fields,omitempty" db:"tax_fields"`
+	IsDefault  bool   `json:"is_default" db:"is_default"`
+	BaseModel
+}
+
+// CreateInvoiceFormatRequest is the payload for creating invoice formats.
+type CreateInvoiceFormatRequest struct {
+	CompanyID  int    `json:"company_id" validate:"required"`
+	LocationID *int   `json:"location_id,omitempty"`
+	SequenceID *int   `json:"sequence_id,omitempty"`
+	Name       string `json:"name" validate:"required"`
+	TaxFields  JSONB  `json:"tax_fields,omitempty"`
+	IsDefault  bool   `json:"is_default,omitempty"`
+}
+
+// UpdateInvoiceFormatRequest is the payload for updating invoice formats.
+type UpdateInvoiceFormatRequest struct {
+	SequenceID *int    `json:"sequence_id,omitempty"`
+	Name       *string `json:"name,omitempty"`
+	TaxFields  *JSONB  `json:"tax_fields,omitempty"`
+	IsDefault  *bool   `json:"is_default,omitempty"`
+}

--- a/internal/models/numbering_sequence.go
+++ b/internal/models/numbering_sequence.go
@@ -1,0 +1,31 @@
+package models
+
+// NumberingSequence defines document numbering settings for a company/location
+// allowing configurable prefixes and sequence lengths.
+type NumberingSequence struct {
+	SequenceID     int     `json:"sequence_id" db:"sequence_id"`
+	CompanyID      int     `json:"company_id" db:"company_id" validate:"required"`
+	LocationID     *int    `json:"location_id,omitempty" db:"location_id"`
+	Name           string  `json:"name" db:"name" validate:"required"`
+	Prefix         *string `json:"prefix,omitempty" db:"prefix"`
+	SequenceLength int     `json:"sequence_length" db:"sequence_length"`
+	CurrentNumber  int     `json:"current_number" db:"current_number"`
+	BaseModel
+}
+
+// CreateNumberingSequenceRequest is the payload for creating a numbering sequence.
+type CreateNumberingSequenceRequest struct {
+	CompanyID      int     `json:"company_id" validate:"required"`
+	LocationID     *int    `json:"location_id,omitempty"`
+	Name           string  `json:"name" validate:"required"`
+	Prefix         *string `json:"prefix,omitempty"`
+	SequenceLength int     `json:"sequence_length" validate:"required"`
+	StartFrom      *int    `json:"start_from,omitempty"`
+}
+
+// UpdateNumberingSequenceRequest is the payload for updating a numbering sequence.
+type UpdateNumberingSequenceRequest struct {
+	Name           *string `json:"name,omitempty" validate:"omitempty"`
+	Prefix         *string `json:"prefix,omitempty" validate:"omitempty"`
+	SequenceLength *int    `json:"sequence_length,omitempty" validate:"omitempty"`
+}


### PR DESCRIPTION
## Summary
- add `numbering_sequences` and `invoice_formats` tables tied to company and location
- allow configurable prefixes, sequence lengths, and tax fields
- add Go models for new invoice configuration

## Testing
- `go vet ./...` *(fails: command hung)*
- `go test ./...` *(fails: command hung)*

------
https://chatgpt.com/codex/tasks/task_e_689e275161cc832cab245629a9a5c7c3