### PR TITLE
Add holidays table and attendance auto-marking

### DIFF
--- a/Docs & Schema/PostgrSQL.sql
+++ b/Docs & Schema/PostgrSQL.sql
@@ -622,6 +622,20 @@ CREATE TABLE employee_leaves (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Holidays Table
+CREATE TABLE holidays (
+    holiday_id SERIAL PRIMARY KEY,
+    company_id INTEGER NOT NULL REFERENCES companies(company_id) ON DELETE CASCADE,
+    date DATE NOT NULL,
+    description TEXT,
+    is_recurring BOOLEAN DEFAULT FALSE,
+    sync_status VARCHAR(20) DEFAULT 'synced',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    is_deleted BOOLEAN DEFAULT FALSE,
+    UNIQUE(company_id, date)
+);
+
 -- Attendance Table
 CREATE TABLE attendance (
     attendance_id SERIAL PRIMARY KEY,

--- a/internal/models/holiday.go
+++ b/internal/models/holiday.go
@@ -1,0 +1,18 @@
+package models
+
+import "time"
+
+type Holiday struct {
+	HolidayID   int       `json:"holiday_id" db:"holiday_id"`
+	CompanyID   int       `json:"company_id" db:"company_id"`
+	Date        time.Time `json:"date" db:"date"`
+	Description *string   `json:"description,omitempty" db:"description"`
+	IsRecurring bool      `json:"is_recurring" db:"is_recurring"`
+	SyncModel
+}
+
+type CreateHolidayRequest struct {
+	Date        time.Time `json:"date" validate:"required"`
+	Description *string   `json:"description,omitempty"`
+	IsRecurring bool      `json:"is_recurring"`
+}

--- a/internal/services/attendance_service.go
+++ b/internal/services/attendance_service.go
@@ -1,0 +1,61 @@
+package services
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"erp-backend/internal/database"
+)
+
+type AttendanceService struct {
+	db *sql.DB
+}
+
+func NewAttendanceService() *AttendanceService {
+	return &AttendanceService{db: database.GetDB()}
+}
+
+// AutoMarkNonWorkingDays inserts ABSENT attendance records for holidays or weekends.
+func (s *AttendanceService) AutoMarkNonWorkingDays(companyID int, date time.Time, userID int) error {
+	weekday := date.Weekday()
+	isWeekend := weekday == time.Saturday || weekday == time.Sunday
+
+	var isHoliday bool
+	err := s.db.QueryRow(`SELECT EXISTS(
+                SELECT 1 FROM holidays
+                WHERE company_id = $1 AND is_deleted = FALSE AND (
+                        date = $2 OR (is_recurring = TRUE AND EXTRACT(MONTH FROM date) = $3 AND EXTRACT(DAY FROM date) = $4)
+                )
+        )`, companyID, date, date.Month(), date.Day()).Scan(&isHoliday)
+	if err != nil {
+		return fmt.Errorf("failed to check holidays: %w", err)
+	}
+
+	if !isWeekend && !isHoliday {
+		return nil
+	}
+
+	note := "Holiday"
+	if isHoliday {
+		var desc sql.NullString
+		if err := s.db.QueryRow(`SELECT description FROM holidays
+                        WHERE company_id = $1 AND is_deleted = FALSE AND (
+                                date = $2 OR (is_recurring = TRUE AND EXTRACT(MONTH FROM date) = $3 AND EXTRACT(DAY FROM date) = $4)
+                        ) LIMIT 1`,
+			companyID, date, date.Month(), date.Day()).Scan(&desc); err == nil && desc.Valid && desc.String != "" {
+			note = desc.String
+		}
+	}
+
+	_, err = s.db.Exec(`INSERT INTO attendance (employee_id, date, status, notes, created_by)
+                SELECT employee_id, $1, 'ABSENT', $2, $3
+                FROM employees
+                WHERE company_id = $4 AND is_deleted = FALSE
+                ON CONFLICT (employee_id, date) DO NOTHING`,
+		date, note, userID, companyID)
+	if err != nil {
+		return fmt.Errorf("failed to insert attendance: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add holidays table to SQL schema
- create holiday model and request struct
- add attendance service to auto-mark holidays and weekends as absent

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e275a6b68832c8678eb4659a8c581