### PR TITLE
Add device session management endpoints

### DIFF
--- a/internal/handlers/device_session.go
+++ b/internal/handlers/device_session.go
@@ -1,0 +1,54 @@
+package handlers
+
+import (
+	"database/sql"
+	"net/http"
+
+	"erp-backend/internal/services"
+	"erp-backend/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+type DeviceSessionHandler struct {
+	service *services.DeviceSessionService
+}
+
+func NewDeviceSessionHandler() *DeviceSessionHandler {
+	return &DeviceSessionHandler{
+		service: services.NewDeviceSessionService(),
+	}
+}
+
+// GET /device-sessions
+func (h *DeviceSessionHandler) GetDeviceSessions(c *gin.Context) {
+	userID := c.GetInt("user_id")
+	companyID := c.GetInt("company_id")
+
+	sessions, err := h.service.GetActiveSessions(userID, companyID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get device sessions", err)
+		return
+	}
+
+	utils.SuccessResponse(c, "Device sessions retrieved successfully", sessions)
+}
+
+// DELETE /device-sessions/:session_id
+func (h *DeviceSessionHandler) RevokeSession(c *gin.Context) {
+	sessionID := c.Param("session_id")
+	userID := c.GetInt("user_id")
+	companyID := c.GetInt("company_id")
+
+	err := h.service.RevokeSession(sessionID, userID, companyID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			utils.NotFoundResponse(c, "Session not found")
+			return
+		}
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to revoke session", err)
+		return
+	}
+
+	utils.SuccessResponse(c, "Session revoked successfully", nil)
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -24,6 +24,7 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 	// Initialize handlers
 	authHandler := handlers.NewAuthHandler()
 	userHandler := handlers.NewUserHandler()
+	deviceSessionHandler := handlers.NewDeviceSessionHandler()
 	companyHandler := handlers.NewCompanyHandler()
 	locationHandler := handlers.NewLocationHandler()
 	roleHandler := handlers.NewRoleHandler()
@@ -84,6 +85,14 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 			{
 				authProtected.GET("/me", authHandler.GetMe)
 				authProtected.POST("/logout", authHandler.Logout)
+			}
+
+			// Device session routes
+			deviceSessions := protected.Group("/device-sessions")
+			deviceSessions.Use(middleware.RequireCompanyAccess())
+			{
+				deviceSessions.GET("", deviceSessionHandler.GetDeviceSessions)
+				deviceSessions.DELETE("/:session_id", deviceSessionHandler.RevokeSession)
 			}
 
 			// Dashboard routes

--- a/internal/services/device_session_service.go
+++ b/internal/services/device_session_service.go
@@ -1,0 +1,80 @@
+package services
+
+import (
+	"database/sql"
+	"fmt"
+
+	"erp-backend/internal/database"
+	"erp-backend/internal/models"
+)
+
+type DeviceSessionService struct {
+	db *sql.DB
+}
+
+func NewDeviceSessionService() *DeviceSessionService {
+	return &DeviceSessionService{
+		db: database.GetDB(),
+	}
+}
+
+func (s *DeviceSessionService) GetActiveSessions(userID, companyID int) ([]models.DeviceSession, error) {
+	query := `
+        SELECT ds.session_id, ds.user_id, ds.device_id, ds.device_name, ds.ip_address,
+               ds.user_agent, ds.last_seen, ds.last_sync_time, ds.is_active, ds.is_stale,
+               ds.created_at
+        FROM device_sessions ds
+        JOIN users u ON ds.user_id = u.user_id
+        WHERE ds.user_id = $1 AND u.company_id = $2 AND ds.is_active = TRUE
+        ORDER BY ds.created_at DESC`
+
+	rows, err := s.db.Query(query, userID, companyID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query device sessions: %w", err)
+	}
+	defer rows.Close()
+
+	sessions := []models.DeviceSession{}
+	for rows.Next() {
+		var session models.DeviceSession
+		err := rows.Scan(
+			&session.SessionID, &session.UserID, &session.DeviceID, &session.DeviceName,
+			&session.IPAddress, &session.UserAgent, &session.LastSeen, &session.LastSyncTime,
+			&session.IsActive, &session.IsStale, &session.CreatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan device session: %w", err)
+		}
+		sessions = append(sessions, session)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate device sessions: %w", err)
+	}
+
+	return sessions, nil
+}
+
+func (s *DeviceSessionService) RevokeSession(sessionID string, userID, companyID int) error {
+	query := `
+        UPDATE device_sessions ds
+        SET is_active = FALSE
+        WHERE ds.session_id = $1 AND ds.user_id = $2
+        AND EXISTS (SELECT 1 FROM users u WHERE u.user_id = ds.user_id AND u.company_id = $3)`
+
+	res, err := s.db.Exec(query, sessionID, userID, companyID)
+	if err != nil {
+		return fmt.Errorf("failed to revoke session: %w", err)
+	}
+
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return sql.ErrNoRows
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- add DeviceSessionHandler and service to list and revoke sessions
- expose `/api/v1/device-sessions` list and delete routes
- filter sessions by authenticated user and company

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689f742c2334832c95479d565b4ae760