### PR TITLE
feat: add language endpoints

### DIFF
--- a/internal/handlers/language.go
+++ b/internal/handlers/language.go
@@ -1,0 +1,51 @@
+package handlers
+
+import (
+	"net/http"
+
+	"erp-backend/internal/services"
+	"erp-backend/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+// LanguageHandler handles language related endpoints
+type LanguageHandler struct {
+	service *services.LanguageService
+}
+
+// NewLanguageHandler creates a new LanguageHandler
+func NewLanguageHandler() *LanguageHandler {
+	return &LanguageHandler{service: services.NewLanguageService()}
+}
+
+// GetLanguages handles GET /languages and returns active languages
+func (h *LanguageHandler) GetLanguages(c *gin.Context) {
+	languages, err := h.service.GetActiveLanguages()
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get languages", err)
+		return
+	}
+	utils.SuccessResponse(c, "Languages retrieved successfully", languages)
+}
+
+// UpdateLanguageStatus handles PUT /languages/:code to activate/deactivate a language
+func (h *LanguageHandler) UpdateLanguageStatus(c *gin.Context) {
+	code := c.Param("code")
+	var req struct {
+		IsActive bool `json:"is_active" validate:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	if err := utils.ValidateStruct(&req); err != nil {
+		utils.ValidationErrorResponse(c, utils.GetValidationErrors(err))
+		return
+	}
+	if err := h.service.UpdateLanguageStatus(code, req.IsActive); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to update language", err)
+		return
+	}
+	utils.SuccessResponse(c, "Language status updated successfully", nil)
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -52,6 +52,7 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 	settingsHandler := handlers.NewSettingsHandler()
 	auditLogHandler := handlers.NewAuditLogHandler()
 	dashboardHandler := handlers.NewDashboardHandler()
+	languageHandler := handlers.NewLanguageHandler()
 	translationHandler := handlers.NewTranslationHandler()
 	printHandler := handlers.NewPrintHandler()
 	// Health check endpoint
@@ -74,6 +75,8 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 			auth.POST("/reset-password", authHandler.ResetPassword)
 			auth.POST("/refresh-token", authHandler.RefreshToken)
 		}
+
+		v1.GET("/languages", languageHandler.GetLanguages)
 
 		// Protected routes (require authentication)
 		protected := v1.Group("")
@@ -500,6 +503,13 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 			audit.Use(middleware.RequireCompanyAccess())
 			{
 				audit.GET("", middleware.RequirePermission("VIEW_AUDIT_LOGS"), auditLogHandler.GetAuditLogs)
+			}
+
+			// Language routes
+			languages := protected.Group("/languages")
+			languages.Use(middleware.RequireRole("Admin"))
+			{
+				languages.PUT("/:code", languageHandler.UpdateLanguageStatus)
 			}
 
 			// Translation routes

--- a/internal/services/language_service.go
+++ b/internal/services/language_service.go
@@ -1,0 +1,54 @@
+package services
+
+import (
+	"database/sql"
+	"fmt"
+
+	"erp-backend/internal/database"
+	"erp-backend/internal/models"
+)
+
+// LanguageService provides language related database operations
+type LanguageService struct {
+	db *sql.DB
+}
+
+// NewLanguageService creates a new LanguageService
+func NewLanguageService() *LanguageService {
+	return &LanguageService{db: database.GetDB()}
+}
+
+// GetActiveLanguages returns all active languages
+func (s *LanguageService) GetActiveLanguages() ([]models.Language, error) {
+	rows, err := s.db.Query(`SELECT language_code, language_name, is_active, created_at FROM languages WHERE is_active = TRUE`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query languages: %w", err)
+	}
+	defer rows.Close()
+
+	var languages []models.Language
+	for rows.Next() {
+		var lang models.Language
+		if err := rows.Scan(&lang.LanguageCode, &lang.LanguageName, &lang.IsActive, &lang.CreatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan language: %w", err)
+		}
+		languages = append(languages, lang)
+	}
+	return languages, nil
+}
+
+// UpdateLanguageStatus updates the active status of a language
+func (s *LanguageService) UpdateLanguageStatus(code string, active bool) error {
+	res, err := s.db.Exec(`UPDATE languages SET is_active = $1 WHERE language_code = $2`, active, code)
+	if err != nil {
+		return fmt.Errorf("failed to update language: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if affected == 0 {
+		return fmt.Errorf("language not found")
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add language service and handler to list and update languages
- expose GET /api/v1/languages and admin PUT /api/v1/languages/:code

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689f75595594832ca24e2056101fcc93