### PR TITLE
Add CRUD for invoice templates and numbering sequences

### DIFF
--- a/internal/handlers/invoice_template.go
+++ b/internal/handlers/invoice_template.go
@@ -1,0 +1,128 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"erp-backend/internal/models"
+	"erp-backend/internal/services"
+	"erp-backend/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+type InvoiceTemplateHandler struct {
+	service *services.InvoiceTemplateService
+}
+
+func NewInvoiceTemplateHandler() *InvoiceTemplateHandler {
+	return &InvoiceTemplateHandler{service: services.NewInvoiceTemplateService()}
+}
+
+// GET /invoice-templates
+func (h *InvoiceTemplateHandler) GetInvoiceTemplates(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	templates, err := h.service.GetInvoiceTemplates(companyID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get invoice templates", err)
+		return
+	}
+	utils.SuccessResponse(c, "Invoice templates retrieved successfully", templates)
+}
+
+// GET /invoice-templates/:id
+func (h *InvoiceTemplateHandler) GetInvoiceTemplate(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid template ID", err)
+		return
+	}
+
+	template, err := h.service.GetInvoiceTemplateByID(id, companyID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to get invoice template", err)
+		return
+	}
+	utils.SuccessResponse(c, "Invoice template retrieved successfully", template)
+}
+
+// POST /invoice-templates
+func (h *InvoiceTemplateHandler) CreateInvoiceTemplate(c *gin.Context) {
+	var req models.CreateInvoiceTemplateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	if err := utils.ValidateStruct(&req); err != nil {
+		validationErrors := utils.GetValidationErrors(err)
+		utils.ValidationErrorResponse(c, validationErrors)
+		return
+	}
+
+	userCompanyID := c.GetInt("company_id")
+	if req.CompanyID != userCompanyID {
+		utils.ForbiddenResponse(c, "Cannot create invoice templates for other companies")
+		return
+	}
+
+	template, err := h.service.CreateInvoiceTemplate(&req)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to create invoice template", err)
+		return
+	}
+	utils.CreatedResponse(c, "Invoice template created successfully", template)
+}
+
+// PUT /invoice-templates/:id
+func (h *InvoiceTemplateHandler) UpdateInvoiceTemplate(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid template ID", err)
+		return
+	}
+	var req models.UpdateInvoiceTemplateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	if err := utils.ValidateStruct(&req); err != nil {
+		validationErrors := utils.GetValidationErrors(err)
+		utils.ValidationErrorResponse(c, validationErrors)
+		return
+	}
+
+	companyID := c.GetInt("company_id")
+	err = h.service.UpdateInvoiceTemplate(id, companyID, &req)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to update invoice template", err)
+		return
+	}
+	utils.SuccessResponse(c, "Invoice template updated successfully", nil)
+}
+
+// DELETE /invoice-templates/:id
+func (h *InvoiceTemplateHandler) DeleteInvoiceTemplate(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid template ID", err)
+		return
+	}
+	companyID := c.GetInt("company_id")
+	err = h.service.DeleteInvoiceTemplate(id, companyID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to delete invoice template", err)
+		return
+	}
+	utils.SuccessResponse(c, "Invoice template deleted successfully", nil)
+}

--- a/internal/handlers/numbering_sequence.go
+++ b/internal/handlers/numbering_sequence.go
@@ -1,0 +1,154 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"erp-backend/internal/models"
+	"erp-backend/internal/services"
+	"erp-backend/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+type NumberingSequenceHandler struct {
+	service *services.NumberingSequenceService
+}
+
+func NewNumberingSequenceHandler() *NumberingSequenceHandler {
+	return &NumberingSequenceHandler{service: services.NewNumberingSequenceService()}
+}
+
+// GET /numbering-sequences
+func (h *NumberingSequenceHandler) GetNumberingSequences(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	var locationID *int
+	if loc := c.Query("location_id"); loc != "" {
+		if id, err := strconv.Atoi(loc); err == nil {
+			locationID = &id
+		}
+	} else if userLoc := c.GetInt("location_id"); userLoc != 0 {
+		locationID = &userLoc
+	}
+
+	sequences, err := h.service.GetNumberingSequences(companyID, locationID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get numbering sequences", err)
+		return
+	}
+	utils.SuccessResponse(c, "Numbering sequences retrieved successfully", sequences)
+}
+
+// GET /numbering-sequences/:id
+func (h *NumberingSequenceHandler) GetNumberingSequence(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid sequence ID", err)
+		return
+	}
+	var locationID *int
+	if loc := c.Query("location_id"); loc != "" {
+		if lid, err := strconv.Atoi(loc); err == nil {
+			locationID = &lid
+		}
+	} else if userLoc := c.GetInt("location_id"); userLoc != 0 {
+		locationID = &userLoc
+	}
+
+	seq, err := h.service.GetNumberingSequenceByID(id, companyID, locationID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to get numbering sequence", err)
+		return
+	}
+	utils.SuccessResponse(c, "Numbering sequence retrieved successfully", seq)
+}
+
+// POST /numbering-sequences
+func (h *NumberingSequenceHandler) CreateNumberingSequence(c *gin.Context) {
+	var req models.CreateNumberingSequenceRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	if err := utils.ValidateStruct(&req); err != nil {
+		validationErrors := utils.GetValidationErrors(err)
+		utils.ValidationErrorResponse(c, validationErrors)
+		return
+	}
+
+	userCompanyID := c.GetInt("company_id")
+	if req.CompanyID != userCompanyID {
+		utils.ForbiddenResponse(c, "Cannot create numbering sequences for other companies")
+		return
+	}
+	if userLoc := c.GetInt("location_id"); userLoc != 0 && req.LocationID != nil && *req.LocationID != userLoc {
+		utils.ForbiddenResponse(c, "Cannot create numbering sequences for other locations")
+		return
+	}
+
+	seq, err := h.service.CreateNumberingSequence(&req)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to create numbering sequence", err)
+		return
+	}
+	utils.CreatedResponse(c, "Numbering sequence created successfully", seq)
+}
+
+// PUT /numbering-sequences/:id
+func (h *NumberingSequenceHandler) UpdateNumberingSequence(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid sequence ID", err)
+		return
+	}
+	var req models.UpdateNumberingSequenceRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	if err := utils.ValidateStruct(&req); err != nil {
+		validationErrors := utils.GetValidationErrors(err)
+		utils.ValidationErrorResponse(c, validationErrors)
+		return
+	}
+	companyID := c.GetInt("company_id")
+	var locationID *int
+	if userLoc := c.GetInt("location_id"); userLoc != 0 {
+		locationID = &userLoc
+	}
+	err = h.service.UpdateNumberingSequence(id, companyID, locationID, &req)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to update numbering sequence", err)
+		return
+	}
+	utils.SuccessResponse(c, "Numbering sequence updated successfully", nil)
+}
+
+// DELETE /numbering-sequences/:id
+func (h *NumberingSequenceHandler) DeleteNumberingSequence(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid sequence ID", err)
+		return
+	}
+	companyID := c.GetInt("company_id")
+	var locationID *int
+	if userLoc := c.GetInt("location_id"); userLoc != 0 {
+		locationID = &userLoc
+	}
+	err = h.service.DeleteNumberingSequence(id, companyID, locationID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to delete numbering sequence", err)
+		return
+	}
+	utils.SuccessResponse(c, "Numbering sequence deleted successfully", nil)
+}

--- a/internal/models/invoice_template.go
+++ b/internal/models/invoice_template.go
@@ -1,0 +1,38 @@
+package models
+
+// InvoiceTemplate represents configurable invoice templates per company.
+type InvoiceTemplate struct {
+	TemplateID        int     `json:"template_id" db:"template_id"`
+	CompanyID         int     `json:"company_id" db:"company_id" validate:"required"`
+	Name              string  `json:"name" db:"name" validate:"required"`
+	TemplateType      string  `json:"template_type" db:"template_type" validate:"required"`
+	Layout            JSONB   `json:"layout" db:"layout" validate:"required"`
+	PrimaryLanguage   *string `json:"primary_language,omitempty" db:"primary_language"`
+	SecondaryLanguage *string `json:"secondary_language,omitempty" db:"secondary_language"`
+	IsDefault         bool    `json:"is_default" db:"is_default"`
+	IsActive          bool    `json:"is_active" db:"is_active"`
+	BaseModel
+}
+
+// CreateInvoiceTemplateRequest is the payload for creating invoice templates.
+type CreateInvoiceTemplateRequest struct {
+	CompanyID         int     `json:"company_id" validate:"required"`
+	Name              string  `json:"name" validate:"required"`
+	TemplateType      string  `json:"template_type" validate:"required"`
+	Layout            JSONB   `json:"layout" validate:"required"`
+	PrimaryLanguage   *string `json:"primary_language,omitempty"`
+	SecondaryLanguage *string `json:"secondary_language,omitempty"`
+	IsDefault         bool    `json:"is_default,omitempty"`
+	IsActive          bool    `json:"is_active,omitempty"`
+}
+
+// UpdateInvoiceTemplateRequest is the payload for updating invoice templates.
+type UpdateInvoiceTemplateRequest struct {
+	Name              *string `json:"name,omitempty"`
+	TemplateType      *string `json:"template_type,omitempty"`
+	Layout            *JSONB  `json:"layout,omitempty"`
+	PrimaryLanguage   *string `json:"primary_language,omitempty"`
+	SecondaryLanguage *string `json:"secondary_language,omitempty"`
+	IsDefault         *bool   `json:"is_default,omitempty"`
+	IsActive          *bool   `json:"is_active,omitempty"`
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -54,6 +54,8 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 	dashboardHandler := handlers.NewDashboardHandler()
 	translationHandler := handlers.NewTranslationHandler()
 	printHandler := handlers.NewPrintHandler()
+	numberingSequenceHandler := handlers.NewNumberingSequenceHandler()
+	invoiceTemplateHandler := handlers.NewInvoiceTemplateHandler()
 	// Health check endpoint
 	router.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
@@ -508,6 +510,28 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 			{
 				translations.GET("", middleware.RequirePermission("VIEW_TRANSLATIONS"), translationHandler.GetTranslations)
 				translations.PUT("", middleware.RequirePermission("MANAGE_TRANSLATIONS"), translationHandler.UpdateTranslations)
+			}
+
+			// Numbering sequence routes
+			numberingSequences := protected.Group("/numbering-sequences")
+			numberingSequences.Use(middleware.RequireCompanyAccess())
+			{
+				numberingSequences.GET("", middleware.RequirePermission("VIEW_SETTINGS"), numberingSequenceHandler.GetNumberingSequences)
+				numberingSequences.GET("/:id", middleware.RequirePermission("VIEW_SETTINGS"), numberingSequenceHandler.GetNumberingSequence)
+				numberingSequences.POST("", middleware.RequirePermission("MANAGE_SETTINGS"), numberingSequenceHandler.CreateNumberingSequence)
+				numberingSequences.PUT("/:id", middleware.RequirePermission("MANAGE_SETTINGS"), numberingSequenceHandler.UpdateNumberingSequence)
+				numberingSequences.DELETE("/:id", middleware.RequirePermission("MANAGE_SETTINGS"), numberingSequenceHandler.DeleteNumberingSequence)
+			}
+
+			// Invoice template routes
+			invoiceTemplates := protected.Group("/invoice-templates")
+			invoiceTemplates.Use(middleware.RequireCompanyAccess())
+			{
+				invoiceTemplates.GET("", middleware.RequirePermission("VIEW_SETTINGS"), invoiceTemplateHandler.GetInvoiceTemplates)
+				invoiceTemplates.GET("/:id", middleware.RequirePermission("VIEW_SETTINGS"), invoiceTemplateHandler.GetInvoiceTemplate)
+				invoiceTemplates.POST("", middleware.RequirePermission("MANAGE_SETTINGS"), invoiceTemplateHandler.CreateInvoiceTemplate)
+				invoiceTemplates.PUT("/:id", middleware.RequirePermission("MANAGE_SETTINGS"), invoiceTemplateHandler.UpdateInvoiceTemplate)
+				invoiceTemplates.DELETE("/:id", middleware.RequirePermission("MANAGE_SETTINGS"), invoiceTemplateHandler.DeleteInvoiceTemplate)
 			}
 
 			// Printing routes

--- a/internal/services/invoice_template_service.go
+++ b/internal/services/invoice_template_service.go
@@ -1,0 +1,153 @@
+package services
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"erp-backend/internal/database"
+	"erp-backend/internal/models"
+)
+
+type InvoiceTemplateService struct {
+	db *sql.DB
+}
+
+func NewInvoiceTemplateService() *InvoiceTemplateService {
+	return &InvoiceTemplateService{db: database.GetDB()}
+}
+
+func (s *InvoiceTemplateService) GetInvoiceTemplates(companyID int) ([]models.InvoiceTemplate, error) {
+	rows, err := s.db.Query(`SELECT template_id, company_id, name, template_type, layout, primary_language, secondary_language, is_default, is_active, created_at FROM invoice_templates WHERE company_id = $1 ORDER BY name`, companyID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get invoice templates: %w", err)
+	}
+	defer rows.Close()
+
+	var templates []models.InvoiceTemplate
+	for rows.Next() {
+		var t models.InvoiceTemplate
+		if err := rows.Scan(&t.TemplateID, &t.CompanyID, &t.Name, &t.TemplateType, &t.Layout, &t.PrimaryLanguage, &t.SecondaryLanguage, &t.IsDefault, &t.IsActive, &t.CreatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan invoice template: %w", err)
+		}
+		templates = append(templates, t)
+	}
+	return templates, nil
+}
+
+func (s *InvoiceTemplateService) GetInvoiceTemplateByID(id, companyID int) (*models.InvoiceTemplate, error) {
+	var t models.InvoiceTemplate
+	err := s.db.QueryRow(`SELECT template_id, company_id, name, template_type, layout, primary_language, secondary_language, is_default, is_active, created_at FROM invoice_templates WHERE template_id = $1 AND company_id = $2`, id, companyID).Scan(&t.TemplateID, &t.CompanyID, &t.Name, &t.TemplateType, &t.Layout, &t.PrimaryLanguage, &t.SecondaryLanguage, &t.IsDefault, &t.IsActive, &t.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("invoice template not found")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get invoice template: %w", err)
+	}
+	return &t, nil
+}
+
+func (s *InvoiceTemplateService) CreateInvoiceTemplate(req *models.CreateInvoiceTemplateRequest) (*models.InvoiceTemplate, error) {
+	exists, err := s.checkCompanyExists(req.CompanyID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check company existence: %w", err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("company not found")
+	}
+
+	var t models.InvoiceTemplate
+	err = s.db.QueryRow(`INSERT INTO invoice_templates (company_id, name, template_type, layout, primary_language, secondary_language, is_default, is_active) VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING template_id, created_at`, req.CompanyID, req.Name, req.TemplateType, req.Layout, req.PrimaryLanguage, req.SecondaryLanguage, req.IsDefault, req.IsActive).Scan(&t.TemplateID, &t.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create invoice template: %w", err)
+	}
+
+	t.CompanyID = req.CompanyID
+	t.Name = req.Name
+	t.TemplateType = req.TemplateType
+	t.Layout = req.Layout
+	t.PrimaryLanguage = req.PrimaryLanguage
+	t.SecondaryLanguage = req.SecondaryLanguage
+	t.IsDefault = req.IsDefault
+	t.IsActive = req.IsActive
+	return &t, nil
+}
+
+func (s *InvoiceTemplateService) UpdateInvoiceTemplate(id, companyID int, req *models.UpdateInvoiceTemplateRequest) error {
+	setParts := []string{}
+	args := []interface{}{}
+
+	if req.Name != nil {
+		setParts = append(setParts, fmt.Sprintf("name = $%d", len(args)+1))
+		args = append(args, *req.Name)
+	}
+	if req.TemplateType != nil {
+		setParts = append(setParts, fmt.Sprintf("template_type = $%d", len(args)+1))
+		args = append(args, *req.TemplateType)
+	}
+	if req.Layout != nil {
+		setParts = append(setParts, fmt.Sprintf("layout = $%d", len(args)+1))
+		args = append(args, *req.Layout)
+	}
+	if req.PrimaryLanguage != nil {
+		setParts = append(setParts, fmt.Sprintf("primary_language = $%d", len(args)+1))
+		args = append(args, *req.PrimaryLanguage)
+	}
+	if req.SecondaryLanguage != nil {
+		setParts = append(setParts, fmt.Sprintf("secondary_language = $%d", len(args)+1))
+		args = append(args, *req.SecondaryLanguage)
+	}
+	if req.IsDefault != nil {
+		setParts = append(setParts, fmt.Sprintf("is_default = $%d", len(args)+1))
+		args = append(args, *req.IsDefault)
+	}
+	if req.IsActive != nil {
+		setParts = append(setParts, fmt.Sprintf("is_active = $%d", len(args)+1))
+		args = append(args, *req.IsActive)
+	}
+
+	if len(setParts) == 0 {
+		return fmt.Errorf("no fields to update")
+	}
+
+	argPos := len(args) + 1
+	query := fmt.Sprintf("UPDATE invoice_templates SET %s WHERE template_id = $%d AND company_id = $%d", strings.Join(setParts, ", "), argPos, argPos+1)
+	args = append(args, id, companyID)
+
+	result, err := s.db.Exec(query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to update invoice template: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("invoice template not found")
+	}
+	return nil
+}
+
+func (s *InvoiceTemplateService) DeleteInvoiceTemplate(id, companyID int) error {
+	result, err := s.db.Exec(`DELETE FROM invoice_templates WHERE template_id = $1 AND company_id = $2`, id, companyID)
+	if err != nil {
+		return fmt.Errorf("failed to delete invoice template: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("invoice template not found")
+	}
+	return nil
+}
+
+func (s *InvoiceTemplateService) checkCompanyExists(companyID int) (bool, error) {
+	var count int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM companies WHERE company_id = $1 AND is_active = TRUE`, companyID).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}

--- a/internal/services/numbering_sequence_service.go
+++ b/internal/services/numbering_sequence_service.go
@@ -1,0 +1,182 @@
+package services
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"erp-backend/internal/database"
+	"erp-backend/internal/models"
+)
+
+type NumberingSequenceService struct {
+	db *sql.DB
+}
+
+func NewNumberingSequenceService() *NumberingSequenceService {
+	return &NumberingSequenceService{db: database.GetDB()}
+}
+
+func (s *NumberingSequenceService) GetNumberingSequences(companyID int, locationID *int) ([]models.NumberingSequence, error) {
+	query := `SELECT sequence_id, company_id, location_id, name, prefix, sequence_length, current_number, created_at, updated_at FROM numbering_sequences WHERE company_id = $1`
+	args := []interface{}{companyID}
+	if locationID != nil {
+		query += " AND (location_id = $2 OR location_id IS NULL)"
+		args = append(args, *locationID)
+	}
+	query += " ORDER BY name"
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get numbering sequences: %w", err)
+	}
+	defer rows.Close()
+
+	var sequences []models.NumberingSequence
+	for rows.Next() {
+		var ns models.NumberingSequence
+		if err := rows.Scan(&ns.SequenceID, &ns.CompanyID, &ns.LocationID, &ns.Name, &ns.Prefix, &ns.SequenceLength, &ns.CurrentNumber, &ns.CreatedAt, &ns.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan numbering sequence: %w", err)
+		}
+		sequences = append(sequences, ns)
+	}
+	return sequences, nil
+}
+
+func (s *NumberingSequenceService) GetNumberingSequenceByID(id, companyID int, locationID *int) (*models.NumberingSequence, error) {
+	query := `SELECT sequence_id, company_id, location_id, name, prefix, sequence_length, current_number, created_at, updated_at FROM numbering_sequences WHERE sequence_id = $1 AND company_id = $2`
+	args := []interface{}{id, companyID}
+	if locationID != nil {
+		query += " AND (location_id = $3 OR location_id IS NULL)"
+		args = append(args, *locationID)
+	}
+	var ns models.NumberingSequence
+	err := s.db.QueryRow(query, args...).Scan(&ns.SequenceID, &ns.CompanyID, &ns.LocationID, &ns.Name, &ns.Prefix, &ns.SequenceLength, &ns.CurrentNumber, &ns.CreatedAt, &ns.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("numbering sequence not found")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get numbering sequence: %w", err)
+	}
+	return &ns, nil
+}
+
+func (s *NumberingSequenceService) CreateNumberingSequence(req *models.CreateNumberingSequenceRequest) (*models.NumberingSequence, error) {
+	exists, err := s.checkCompanyExists(req.CompanyID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check company existence: %w", err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("company not found")
+	}
+	if req.LocationID != nil {
+		ok, err := s.checkLocationBelongsToCompany(req.CompanyID, *req.LocationID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check location existence: %w", err)
+		}
+		if !ok {
+			return nil, fmt.Errorf("location not found")
+		}
+	}
+
+	start := 0
+	if req.StartFrom != nil {
+		start = *req.StartFrom
+	}
+
+	var ns models.NumberingSequence
+	err = s.db.QueryRow(`INSERT INTO numbering_sequences (company_id, location_id, name, prefix, sequence_length, current_number) VALUES ($1,$2,$3,$4,$5,$6) RETURNING sequence_id, current_number, created_at, updated_at`, req.CompanyID, req.LocationID, req.Name, req.Prefix, req.SequenceLength, start).Scan(&ns.SequenceID, &ns.CurrentNumber, &ns.CreatedAt, &ns.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create numbering sequence: %w", err)
+	}
+
+	ns.CompanyID = req.CompanyID
+	ns.LocationID = req.LocationID
+	ns.Name = req.Name
+	ns.Prefix = req.Prefix
+	ns.SequenceLength = req.SequenceLength
+	return &ns, nil
+}
+
+func (s *NumberingSequenceService) UpdateNumberingSequence(id, companyID int, locationID *int, req *models.UpdateNumberingSequenceRequest) error {
+	setParts := []string{}
+	args := []interface{}{}
+
+	if req.Name != nil {
+		setParts = append(setParts, fmt.Sprintf("name = $%d", len(args)+1))
+		args = append(args, *req.Name)
+	}
+	if req.Prefix != nil {
+		setParts = append(setParts, fmt.Sprintf("prefix = $%d", len(args)+1))
+		args = append(args, *req.Prefix)
+	}
+	if req.SequenceLength != nil {
+		setParts = append(setParts, fmt.Sprintf("sequence_length = $%d", len(args)+1))
+		args = append(args, *req.SequenceLength)
+	}
+
+	if len(setParts) == 0 {
+		return fmt.Errorf("no fields to update")
+	}
+
+	setParts = append(setParts, "updated_at = CURRENT_TIMESTAMP")
+	argPos := len(args) + 1
+	query := fmt.Sprintf("UPDATE numbering_sequences SET %s WHERE sequence_id = $%d AND company_id = $%d", strings.Join(setParts, ", "), argPos, argPos+1)
+	args = append(args, id, companyID)
+	if locationID != nil {
+		query += fmt.Sprintf(" AND (location_id = $%d OR location_id IS NULL)", argPos+2)
+		args = append(args, *locationID)
+	}
+
+	result, err := s.db.Exec(query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to update numbering sequence: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("numbering sequence not found")
+	}
+	return nil
+}
+
+func (s *NumberingSequenceService) DeleteNumberingSequence(id, companyID int, locationID *int) error {
+	query := "DELETE FROM numbering_sequences WHERE sequence_id = $1 AND company_id = $2"
+	args := []interface{}{id, companyID}
+	if locationID != nil {
+		query += " AND (location_id = $3 OR location_id IS NULL)"
+		args = append(args, *locationID)
+	}
+	result, err := s.db.Exec(query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to delete numbering sequence: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("numbering sequence not found")
+	}
+	return nil
+}
+
+func (s *NumberingSequenceService) checkCompanyExists(companyID int) (bool, error) {
+	var count int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM companies WHERE company_id = $1 AND is_active = TRUE`, companyID).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func (s *NumberingSequenceService) checkLocationBelongsToCompany(companyID, locationID int) (bool, error) {
+	var count int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM locations WHERE location_id = $1 AND company_id = $2 AND is_active = TRUE`, locationID, companyID).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}


### PR DESCRIPTION
## Summary
- add invoice template model, service, and handlers
- add numbering sequence service and handlers
- register invoice-template and numbering-sequence routes

## Testing
- `go test ./internal/...`


------
https://chatgpt.com/codex/tasks/task_e_689f7554a718832c84d278b26707d68c