### PR TITLE
Add category-based promotion eligibility

### DIFF
--- a/internal/models/loyalty.go
+++ b/internal/models/loyalty.go
@@ -103,10 +103,20 @@ type CustomerLoyaltyResponse struct {
 	RecentActivity []LoyaltyTransaction `json:"recent_activity"`
 }
 
+// PromotionEligibilityRequest defines the payload for checking promotion eligibility.
+// Expected JSON format:
+//
+//	{
+//	  "customer_id": 123,       // optional
+//	  "total_amount": 100.0,    // required
+//	  "product_ids": [1,2],     // optional - products in the transaction
+//	  "category_ids": [10,20]   // optional - categories represented in the transaction
+//	}
 type PromotionEligibilityRequest struct {
 	CustomerID  *int    `json:"customer_id,omitempty"`
 	TotalAmount float64 `json:"total_amount" validate:"required,gt=0"`
 	ProductIDs  []int   `json:"product_ids,omitempty"`
+	CategoryIDs []int   `json:"category_ids,omitempty"`
 }
 
 type PromotionEligibilityResponse struct {


### PR DESCRIPTION
## Summary
- document promotion eligibility request format and support category IDs
- parse promotion applicability for products or categories when computing eligibility
- surface product category IDs during sale eligibility checks

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689f77611d74832c88f59e12d0250c1b