### PR TITLE
Implement password reset token flow with email

### DIFF
--- a/internal/models/auth.go
+++ b/internal/models/auth.go
@@ -26,8 +26,7 @@ type ForgotPasswordRequest struct {
 }
 
 type ResetPasswordRequest struct {
-	Email       string `json:"email" validate:"required,email"`
-	ResetCode   string `json:"reset_code" validate:"required"`
+	Token       string `json:"token" validate:"required"`
 	NewPassword string `json:"new_password" validate:"required,min=6"`
 }
 

--- a/internal/utils/email.go
+++ b/internal/utils/email.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"fmt"
+	"net/smtp"
+
+	"erp-backend/internal/config"
+)
+
+// SendEmail sends an email using configured SMTP credentials
+func SendEmail(to, subject, body string) error {
+	cfg := config.Load()
+	if cfg.SMTPHost == "" {
+		return fmt.Errorf("smtp host not configured")
+	}
+
+	addr := fmt.Sprintf("%s:%d", cfg.SMTPHost, cfg.SMTPPort)
+	auth := smtp.PlainAuth("", cfg.SMTPUsername, cfg.SMTPPassword, cfg.SMTPHost)
+
+	msg := []byte(fmt.Sprintf("To: %s\r\nSubject: %s\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=\"UTF-8\"\r\n\r\n%s", to, subject, body))
+
+	return smtp.SendMail(addr, auth, cfg.FromEmail, []string{to}, msg)
+}


### PR DESCRIPTION
## Summary
- add email utility for SMTP sending
- generate and validate password reset tokens
- update ResetPasswordRequest to use token and new password

## Testing
- `go test ./...` *(fails: missing go.sum entry for github.com/google/uuid)*
- `GOSUMDB=off go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_689f777b5f7c832ca084d904f8b362ba