### PR TITLE
Track workflow authorship

### DIFF
--- a/Docs & Schema/PostgrSQL.sql
+++ b/Docs & Schema/PostgrSQL.sql
@@ -1182,7 +1182,9 @@ CREATE POLICY collections_rls ON collections FOR ALL TO authenticated
 CREATE TABLE workflow_templates (
     workflow_id SERIAL PRIMARY KEY,
     name VARCHAR(100),
-    description TEXT
+    description TEXT,
+    created_by INT NOT NULL REFERENCES users(user_id),
+    updated_by INT REFERENCES users(user_id)
 );
 
 CREATE TABLE workflow_states (
@@ -1190,7 +1192,9 @@ CREATE TABLE workflow_states (
     workflow_id INT REFERENCES workflow_templates(workflow_id),
     state_name VARCHAR(100),
     sequence INT,
-    is_final BOOLEAN DEFAULT FALSE
+    is_final BOOLEAN DEFAULT FALSE,
+    created_by INT NOT NULL REFERENCES users(user_id),
+    updated_by INT REFERENCES users(user_id)
 );
 
 CREATE TABLE workflow_approvals (
@@ -1199,7 +1203,9 @@ CREATE TABLE workflow_approvals (
     approver_role_id INT REFERENCES roles(role_id),
     status VARCHAR(50),
     remarks TEXT,
-    approved_at TIMESTAMP
+    approved_at TIMESTAMP,
+    created_by INT NOT NULL REFERENCES users(user_id),
+    updated_by INT REFERENCES users(user_id)
 );
 
 ALTER TABLE workflow_templates ENABLE ROW LEVEL SECURITY;

--- a/Docs & Schema/workflow_user_backfill.sql
+++ b/Docs & Schema/workflow_user_backfill.sql
@@ -1,0 +1,14 @@
+ALTER TABLE workflow_templates ADD COLUMN IF NOT EXISTS created_by INT REFERENCES users(user_id);
+ALTER TABLE workflow_templates ADD COLUMN IF NOT EXISTS updated_by INT REFERENCES users(user_id);
+UPDATE workflow_templates SET created_by = 1, updated_by = 1 WHERE created_by IS NULL;
+ALTER TABLE workflow_templates ALTER COLUMN created_by SET NOT NULL;
+
+ALTER TABLE workflow_states ADD COLUMN IF NOT EXISTS created_by INT REFERENCES users(user_id);
+ALTER TABLE workflow_states ADD COLUMN IF NOT EXISTS updated_by INT REFERENCES users(user_id);
+UPDATE workflow_states SET created_by = 1, updated_by = 1 WHERE created_by IS NULL;
+ALTER TABLE workflow_states ALTER COLUMN created_by SET NOT NULL;
+
+ALTER TABLE workflow_approvals ADD COLUMN IF NOT EXISTS created_by INT REFERENCES users(user_id);
+ALTER TABLE workflow_approvals ADD COLUMN IF NOT EXISTS updated_by INT REFERENCES users(user_id);
+UPDATE workflow_approvals SET created_by = 1, updated_by = 1 WHERE created_by IS NULL;
+ALTER TABLE workflow_approvals ALTER COLUMN created_by SET NOT NULL;

--- a/internal/handlers/workflow.go
+++ b/internal/handlers/workflow.go
@@ -43,7 +43,8 @@ func (h *WorkflowHandler) CreateWorkflowRequest(c *gin.Context) {
 		return
 	}
 
-	request, err := h.service.CreateRequest(&req)
+	userID := c.GetInt("user_id")
+	request, err := h.service.CreateRequest(userID, &req)
 	if err != nil {
 		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to create workflow request", err)
 		return
@@ -65,7 +66,8 @@ func (h *WorkflowHandler) ApproveWorkflowRequest(c *gin.Context) {
 		return
 	}
 
-	if err := h.service.ApproveRequest(id, req.Remarks); err != nil {
+	userID := c.GetInt("user_id")
+	if err := h.service.ApproveRequest(id, userID, req.Remarks); err != nil {
 		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to approve workflow request", err)
 		return
 	}
@@ -86,7 +88,8 @@ func (h *WorkflowHandler) RejectWorkflowRequest(c *gin.Context) {
 		return
 	}
 
-	if err := h.service.RejectRequest(id, req.Remarks); err != nil {
+	userID := c.GetInt("user_id")
+	if err := h.service.RejectRequest(id, userID, req.Remarks); err != nil {
 		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to reject workflow request", err)
 		return
 	}

--- a/internal/models/workflow.go
+++ b/internal/models/workflow.go
@@ -11,6 +11,8 @@ type WorkflowRequest struct {
 	Status         string     `json:"status" db:"status"`
 	Remarks        *string    `json:"remarks,omitempty" db:"remarks"`
 	ApprovedAt     *time.Time `json:"approved_at,omitempty" db:"approved_at"`
+	CreatedBy      int        `json:"created_by" db:"created_by"`
+	UpdatedBy      *int       `json:"updated_by,omitempty" db:"updated_by"`
 }
 
 // CreateWorkflowRequest is used to submit a new workflow approval request

--- a/internal/services/workflow_service.go
+++ b/internal/services/workflow_service.go
@@ -19,7 +19,7 @@ func NewWorkflowService() *WorkflowService {
 
 // GetPendingRequests retrieves all workflow approvals with status PENDING
 func (s *WorkflowService) GetPendingRequests() ([]models.WorkflowRequest, error) {
-	rows, err := s.db.Query(`SELECT approval_id, state_id, approver_role_id, status, remarks, approved_at FROM workflow_approvals WHERE status = 'PENDING'`)
+	rows, err := s.db.Query(`SELECT approval_id, state_id, approver_role_id, status, remarks, approved_at, created_by, updated_by FROM workflow_approvals WHERE status = 'PENDING'`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get workflow requests: %w", err)
 	}
@@ -28,7 +28,7 @@ func (s *WorkflowService) GetPendingRequests() ([]models.WorkflowRequest, error)
 	var requests []models.WorkflowRequest
 	for rows.Next() {
 		var r models.WorkflowRequest
-		if err := rows.Scan(&r.ApprovalID, &r.StateID, &r.ApproverRoleID, &r.Status, &r.Remarks, &r.ApprovedAt); err != nil {
+		if err := rows.Scan(&r.ApprovalID, &r.StateID, &r.ApproverRoleID, &r.Status, &r.Remarks, &r.ApprovedAt, &r.CreatedBy, &r.UpdatedBy); err != nil {
 			return nil, fmt.Errorf("failed to scan workflow request: %w", err)
 		}
 		requests = append(requests, r)
@@ -37,24 +37,27 @@ func (s *WorkflowService) GetPendingRequests() ([]models.WorkflowRequest, error)
 }
 
 // CreateRequest inserts a new workflow approval request
-func (s *WorkflowService) CreateRequest(req *models.CreateWorkflowRequest) (*models.WorkflowRequest, error) {
+func (s *WorkflowService) CreateRequest(userID int, req *models.CreateWorkflowRequest) (*models.WorkflowRequest, error) {
 	var id int
-	err := s.db.QueryRow(`INSERT INTO workflow_approvals (state_id, approver_role_id, status) VALUES ($1, $2, 'PENDING') RETURNING approval_id`, req.StateID, req.ApproverRoleID).Scan(&id)
+	err := s.db.QueryRow(`INSERT INTO workflow_approvals (state_id, approver_role_id, status, created_by, updated_by) VALUES ($1, $2, 'PENDING', $3, $3) RETURNING approval_id`, req.StateID, req.ApproverRoleID, userID).Scan(&id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create workflow request: %w", err)
 	}
 
+	updatedBy := userID
 	return &models.WorkflowRequest{
 		ApprovalID:     id,
 		StateID:        req.StateID,
 		ApproverRoleID: req.ApproverRoleID,
 		Status:         "PENDING",
+		CreatedBy:      userID,
+		UpdatedBy:      &updatedBy,
 	}, nil
 }
 
 // ApproveRequest marks a workflow request as approved
-func (s *WorkflowService) ApproveRequest(id int, remarks *string) error {
-	_, err := s.db.Exec(`UPDATE workflow_approvals SET status = 'APPROVED', remarks = $1, approved_at = NOW() WHERE approval_id = $2`, remarks, id)
+func (s *WorkflowService) ApproveRequest(id, userID int, remarks *string) error {
+	_, err := s.db.Exec(`UPDATE workflow_approvals SET status = 'APPROVED', remarks = $1, approved_at = NOW(), updated_by = $2 WHERE approval_id = $3`, remarks, userID, id)
 	if err != nil {
 		return fmt.Errorf("failed to approve workflow request: %w", err)
 	}
@@ -62,8 +65,8 @@ func (s *WorkflowService) ApproveRequest(id int, remarks *string) error {
 }
 
 // RejectRequest marks a workflow request as rejected
-func (s *WorkflowService) RejectRequest(id int, remarks *string) error {
-	_, err := s.db.Exec(`UPDATE workflow_approvals SET status = 'REJECTED', remarks = $1, approved_at = NOW() WHERE approval_id = $2`, remarks, id)
+func (s *WorkflowService) RejectRequest(id, userID int, remarks *string) error {
+	_, err := s.db.Exec(`UPDATE workflow_approvals SET status = 'REJECTED', remarks = $1, approved_at = NOW(), updated_by = $2 WHERE approval_id = $3`, remarks, userID, id)
 	if err != nil {
 		return fmt.Errorf("failed to reject workflow request: %w", err)
 	}


### PR DESCRIPTION
## Summary
- add created_by and updated_by columns to workflow tables and provide a backfill script
- capture authenticated user on workflow request creation and decisions
- expose workflow request authorship in API models

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0a5c8d140832cb04c4e5704d33077