### PR TITLE
Record device sessions and enforce login session limits

### DIFF
--- a/internal/handlers/auth.go
+++ b/internal/handlers/auth.go
@@ -35,8 +35,11 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		return
 	}
 
+	ipAddress := c.ClientIP()
+	userAgent := c.GetHeader("User-Agent")
+
 	// Authenticate user
-	response, err := h.authService.Login(&req)
+	response, err := h.authService.Login(&req, ipAddress, userAgent)
 	if err != nil {
 		utils.ErrorResponse(c, http.StatusUnauthorized, "Authentication failed", err)
 		return

--- a/internal/models/auth.go
+++ b/internal/models/auth.go
@@ -3,13 +3,16 @@ package models
 import "time"
 
 type LoginRequest struct {
-	Email    string `json:"email" validate:"required,email"`
-	Password string `json:"password" validate:"required"`
+	Email      string  `json:"email" validate:"required,email"`
+	Password   string  `json:"password" validate:"required"`
+	DeviceID   string  `json:"device_id" validate:"required"`
+	DeviceName *string `json:"device_name,omitempty"`
 }
 
 type LoginResponse struct {
 	AccessToken  string       `json:"access_token"`
 	RefreshToken string       `json:"refresh_token"`
+	SessionID    string       `json:"session_id"`
 	User         UserResponse `json:"user"`
 }
 


### PR DESCRIPTION
## Summary
- capture device and network info on login and return session ID
- enforce configurable max session limit by revoking older sessions

## Testing
- `go test ./...` *(hangs, terminated)*
- `go build ./...` *(hangs, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a9572b5c832c8b55b9d0c228a2ca