### PR TITLE
Enforce paid amount check for sales

### DIFF
--- a/Docs & Schema/PostgrSQL.sql
+++ b/Docs & Schema/PostgrSQL.sql
@@ -328,7 +328,7 @@ CREATE TABLE sales (
     tax_amount NUMERIC(12,2) DEFAULT 0,
     discount_amount NUMERIC(12,2) DEFAULT 0,
     total_amount NUMERIC(12,2) NOT NULL DEFAULT 0,
-    paid_amount NUMERIC(12,2) DEFAULT 0,
+    paid_amount NUMERIC(12,2) DEFAULT 0 CHECK (paid_amount <= total_amount),
     payment_method_id INTEGER REFERENCES payment_methods(method_id),
     status VARCHAR(50) DEFAULT 'COMPLETED' CHECK (status IN ('DRAFT', 'COMPLETED', 'VOID', 'RETURNED')),
     pos_status VARCHAR(20) DEFAULT 'COMPLETED' CHECK (pos_status IN ('HOLD', 'ACTIVE', 'COMPLETED')),

--- a/internal/handlers/sales.go
+++ b/internal/handlers/sales.go
@@ -141,6 +141,10 @@ func (h *SalesHandler) CreateSale(c *gin.Context) {
 			utils.NotFoundResponse(c, "Customer not found")
 			return
 		}
+		if err.Error() == "paid amount cannot exceed total amount" {
+			utils.ValidationErrorResponse(c, map[string]string{"paid_amount": "cannot exceed total_amount"})
+			return
+		}
 		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to create sale", err)
 		return
 	}

--- a/internal/handlers/sales_test.go
+++ b/internal/handlers/sales_test.go
@@ -1,0 +1,60 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"erp-backend/internal/models"
+	"erp-backend/internal/services"
+	"erp-backend/internal/utils"
+)
+
+// TestCreateSale_PaidAmountExceedsTotal ensures the handler returns a validation
+// error when the paid amount is greater than the total amount.
+func TestCreateSale_PaidAmountExceedsTotal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	utils.InitializeValidator()
+
+	handler := &SalesHandler{salesService: &services.SalesService{}}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	body := []byte(`{"items":[{"quantity":1,"unit_price":10}],"paid_amount":20}`)
+	req, _ := http.NewRequest(http.MethodPost, "/sales", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	c.Set("company_id", 1)
+	c.Set("location_id", 1)
+	c.Set("user_id", 1)
+
+	handler.CreateSale(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", w.Code)
+	}
+
+	var resp models.APIResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Message != "Validation failed" {
+		t.Fatalf("unexpected message: %s", resp.Message)
+	}
+
+	data, ok := resp.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected data map, got %T", resp.Data)
+	}
+
+	if v, ok := data["paid_amount"].(string); !ok || v != "cannot exceed total_amount" {
+		t.Fatalf("unexpected validation error: %v", resp.Data)
+	}
+}

--- a/internal/services/sales_service.go
+++ b/internal/services/sales_service.go
@@ -377,6 +377,11 @@ func (s *SalesService) CreateSale(companyID, locationID, userID int, req *models
 
 	totalAmount := subtotal + totalTax - req.DiscountAmount
 
+	// Validate paid amount does not exceed total amount
+	if req.PaidAmount > totalAmount {
+		return nil, fmt.Errorf("paid amount cannot exceed total amount")
+	}
+
 	// Start transaction
 	tx, err := s.db.Begin()
 	if err != nil {

--- a/internal/services/sales_service_test.go
+++ b/internal/services/sales_service_test.go
@@ -1,0 +1,29 @@
+package services
+
+import (
+	"testing"
+
+	"erp-backend/internal/models"
+)
+
+// TestCreateSale_PaidAmountExceedsTotal verifies that CreateSale returns an error
+// when the paid amount is greater than the total amount.
+func TestCreateSale_PaidAmountExceedsTotal(t *testing.T) {
+	svc := &SalesService{}
+
+	req := &models.CreateSaleRequest{
+		Items: []models.CreateSaleDetailRequest{
+			{Quantity: 1, UnitPrice: 10},
+		},
+		PaidAmount: 20, // Greater than calculated total of 10
+	}
+
+	_, err := svc.CreateSale(1, 1, 1, req)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+
+	if err.Error() != "paid amount cannot exceed total amount" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add DB check ensuring a sale's paid_amount never exceeds total_amount
- validate paid amount in SalesService before inserting a sale
- return a clear validation error from the sales handler when the rule is violated
- add unit tests for service and handler

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0b936f500832cad33bb93c485dd00