### PR TITLE
Add currency CRUD endpoints

### DIFF
--- a/internal/handlers/currency.go
+++ b/internal/handlers/currency.go
@@ -1,0 +1,132 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"erp-backend/internal/models"
+	"erp-backend/internal/services"
+	"erp-backend/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+// CurrencyHandler handles currency related endpoints
+type CurrencyHandler struct {
+	service *services.CurrencyService
+}
+
+// NewCurrencyHandler creates a new CurrencyHandler
+func NewCurrencyHandler() *CurrencyHandler {
+	return &CurrencyHandler{service: services.NewCurrencyService()}
+}
+
+// GetCurrencies handles GET /currencies
+func (h *CurrencyHandler) GetCurrencies(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	currencies, err := h.service.GetCurrencies()
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get currencies", err)
+		return
+	}
+	utils.SuccessResponse(c, "Currencies retrieved successfully", currencies)
+}
+
+// CreateCurrency handles POST /currencies
+func (h *CurrencyHandler) CreateCurrency(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	var req models.CreateCurrencyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	req.Code = strings.ToUpper(req.Code)
+
+	if err := utils.ValidateStruct(&req); err != nil {
+		utils.ValidationErrorResponse(c, utils.GetValidationErrors(err))
+		return
+	}
+
+	currency, err := h.service.CreateCurrency(&req)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to create currency", err)
+		return
+	}
+	utils.CreatedResponse(c, "Currency created successfully", currency)
+}
+
+// UpdateCurrency handles PUT/PATCH /currencies/:id
+func (h *CurrencyHandler) UpdateCurrency(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid currency ID", err)
+		return
+	}
+
+	var req models.UpdateCurrencyRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	if req.Code != nil {
+		code := strings.ToUpper(*req.Code)
+		req.Code = &code
+	}
+
+	if err := utils.ValidateStruct(&req); err != nil {
+		utils.ValidationErrorResponse(c, utils.GetValidationErrors(err))
+		return
+	}
+
+	if err := h.service.UpdateCurrency(id, &req); err != nil {
+		if err.Error() == "currency not found" {
+			utils.NotFoundResponse(c, "Currency not found")
+			return
+		}
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to update currency", err)
+		return
+	}
+	utils.SuccessResponse(c, "Currency updated successfully", nil)
+}
+
+// DeleteCurrency handles DELETE /currencies/:id
+func (h *CurrencyHandler) DeleteCurrency(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid currency ID", err)
+		return
+	}
+
+	if err := h.service.DeleteCurrency(id); err != nil {
+		if err.Error() == "currency not found" {
+			utils.NotFoundResponse(c, "Currency not found")
+			return
+		}
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to delete currency", err)
+		return
+	}
+	utils.SuccessResponse(c, "Currency deleted successfully", nil)
+}

--- a/internal/models/currency_request.go
+++ b/internal/models/currency_request.go
@@ -1,0 +1,21 @@
+package models
+
+// CreateCurrencyRequest represents request body for creating a currency
+// Code should be a unique currency code (e.g. USD)
+type CreateCurrencyRequest struct {
+	Code           string  `json:"code" validate:"required,alpha,len=3"`
+	Name           string  `json:"name" validate:"required"`
+	Symbol         *string `json:"symbol,omitempty" validate:"omitempty,max=10"`
+	ExchangeRate   float64 `json:"exchange_rate" validate:"required,gt=0"`
+	IsBaseCurrency bool    `json:"is_base_currency"`
+}
+
+// UpdateCurrencyRequest represents request body for updating a currency
+// Fields are optional; only provided fields will be updated
+type UpdateCurrencyRequest struct {
+	Code           *string  `json:"code,omitempty" validate:"omitempty,alpha,len=3"`
+	Name           *string  `json:"name,omitempty"`
+	Symbol         *string  `json:"symbol,omitempty" validate:"omitempty,max=10"`
+	ExchangeRate   *float64 `json:"exchange_rate,omitempty" validate:"omitempty,gt=0"`
+	IsBaseCurrency *bool    `json:"is_base_currency,omitempty"`
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -58,6 +58,7 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 	printHandler := handlers.NewPrintHandler()
 	numberingSequenceHandler := handlers.NewNumberingSequenceHandler()
 	invoiceTemplateHandler := handlers.NewInvoiceTemplateHandler()
+	currencyHandler := handlers.NewCurrencyHandler()
 	// Health check endpoint
 	router.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
@@ -477,6 +478,17 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 				suppliers.POST("", middleware.RequirePermission("CREATE_SUPPLIERS"), supplierHandler.CreateSupplier)
 				suppliers.PUT("/:id", middleware.RequirePermission("UPDATE_SUPPLIERS"), supplierHandler.UpdateSupplier)
 				suppliers.DELETE("/:id", middleware.RequirePermission("DELETE_SUPPLIERS"), supplierHandler.DeleteSupplier)
+			}
+
+			// Currency routes
+			currencies := protected.Group("/currencies")
+			currencies.Use(middleware.RequireCompanyAccess())
+			{
+				currencies.GET("", middleware.RequirePermission("VIEW_SETTINGS"), currencyHandler.GetCurrencies)
+				currencies.POST("", middleware.RequirePermission("MANAGE_SETTINGS"), currencyHandler.CreateCurrency)
+				currencies.PUT("/:id", middleware.RequirePermission("MANAGE_SETTINGS"), currencyHandler.UpdateCurrency)
+				currencies.PATCH("/:id", middleware.RequirePermission("MANAGE_SETTINGS"), currencyHandler.UpdateCurrency)
+				currencies.DELETE("/:id", middleware.RequirePermission("MANAGE_SETTINGS"), currencyHandler.DeleteCurrency)
 			}
 
 			// Settings routes

--- a/internal/services/currency_service.go
+++ b/internal/services/currency_service.go
@@ -1,0 +1,146 @@
+package services
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"erp-backend/internal/database"
+	"erp-backend/internal/models"
+)
+
+// CurrencyService provides CRUD operations for currencies
+type CurrencyService struct {
+	db *sql.DB
+}
+
+// NewCurrencyService creates a new CurrencyService
+func NewCurrencyService() *CurrencyService {
+	return &CurrencyService{db: database.GetDB()}
+}
+
+// GetCurrencies returns all non-deleted currencies
+func (s *CurrencyService) GetCurrencies() ([]models.Currency, error) {
+	query := `SELECT currency_id, code, name, symbol, exchange_rate, is_base_currency, created_at, updated_at
+              FROM currencies WHERE is_deleted = FALSE ORDER BY code`
+	rows, err := s.db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get currencies: %w", err)
+	}
+	defer rows.Close()
+
+	var currencies []models.Currency
+	for rows.Next() {
+		var cur models.Currency
+		if err := rows.Scan(&cur.CurrencyID, &cur.Code, &cur.Name, &cur.Symbol,
+			&cur.ExchangeRate, &cur.IsBaseCurrency, &cur.CreatedAt, &cur.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan currency: %w", err)
+		}
+		currencies = append(currencies, cur)
+	}
+	return currencies, nil
+}
+
+// CreateCurrency creates a new currency
+func (s *CurrencyService) CreateCurrency(req *models.CreateCurrencyRequest) (*models.Currency, error) {
+	var exists bool
+	if err := s.db.QueryRow(`SELECT EXISTS(SELECT 1 FROM currencies WHERE code = $1 AND is_deleted = FALSE)`, req.Code).Scan(&exists); err != nil {
+		return nil, fmt.Errorf("failed to check currency code: %w", err)
+	}
+	if exists {
+		return nil, fmt.Errorf("currency code already exists")
+	}
+
+	query := `INSERT INTO currencies (code, name, symbol, exchange_rate, is_base_currency)
+              VALUES ($1, $2, $3, $4, $5) RETURNING currency_id, created_at, updated_at`
+	var cur models.Currency
+	if err := s.db.QueryRow(query, req.Code, req.Name, req.Symbol, req.ExchangeRate, req.IsBaseCurrency).
+		Scan(&cur.CurrencyID, &cur.CreatedAt, &cur.UpdatedAt); err != nil {
+		return nil, fmt.Errorf("failed to create currency: %w", err)
+	}
+	cur.Code = req.Code
+	cur.Name = req.Name
+	cur.Symbol = req.Symbol
+	cur.ExchangeRate = req.ExchangeRate
+	cur.IsBaseCurrency = req.IsBaseCurrency
+	return &cur, nil
+}
+
+// UpdateCurrency updates an existing currency
+func (s *CurrencyService) UpdateCurrency(id int, req *models.UpdateCurrencyRequest) error {
+	setParts := []string{}
+	args := []interface{}{}
+	argCount := 0
+
+	if req.Code != nil {
+		var exists bool
+		if err := s.db.QueryRow(`SELECT EXISTS(SELECT 1 FROM currencies WHERE code = $1 AND currency_id <> $2 AND is_deleted = FALSE)`, *req.Code, id).Scan(&exists); err != nil {
+			return fmt.Errorf("failed to check currency code: %w", err)
+		}
+		if exists {
+			return fmt.Errorf("currency code already exists")
+		}
+		argCount++
+		setParts = append(setParts, fmt.Sprintf("code = $%d", argCount))
+		args = append(args, *req.Code)
+	}
+	if req.Name != nil {
+		argCount++
+		setParts = append(setParts, fmt.Sprintf("name = $%d", argCount))
+		args = append(args, *req.Name)
+	}
+	if req.Symbol != nil {
+		argCount++
+		setParts = append(setParts, fmt.Sprintf("symbol = $%d", argCount))
+		args = append(args, *req.Symbol)
+	}
+	if req.ExchangeRate != nil {
+		argCount++
+		setParts = append(setParts, fmt.Sprintf("exchange_rate = $%d", argCount))
+		args = append(args, *req.ExchangeRate)
+	}
+	if req.IsBaseCurrency != nil {
+		argCount++
+		setParts = append(setParts, fmt.Sprintf("is_base_currency = $%d", argCount))
+		args = append(args, *req.IsBaseCurrency)
+	}
+	if len(setParts) == 0 {
+		return fmt.Errorf("no fields to update")
+	}
+
+	// always update timestamp
+	setParts = append(setParts, "updated_at = CURRENT_TIMESTAMP")
+
+	argCount++
+	query := fmt.Sprintf("UPDATE currencies SET %s WHERE currency_id = $%d AND is_deleted = FALSE", strings.Join(setParts, ", "), argCount)
+	args = append(args, id)
+
+	res, err := s.db.Exec(query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to update currency: %w", err)
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return fmt.Errorf("currency not found")
+	}
+	return nil
+}
+
+// DeleteCurrency marks a currency as deleted
+func (s *CurrencyService) DeleteCurrency(id int) error {
+	res, err := s.db.Exec(`UPDATE currencies SET is_deleted = TRUE, updated_at = CURRENT_TIMESTAMP WHERE currency_id = $1 AND is_deleted = FALSE`, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete currency: %w", err)
+	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return fmt.Errorf("currency not found")
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add currency service and handler for full CRUD
- register `/api/v1/currencies` routes with company scoping and permissions
- define request models with validation rules

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0bb3a6984832cb41344e2fba9409e