### PR TITLE
Add tax CRUD support with service, handler, and routes

### DIFF
--- a/internal/handlers/tax.go
+++ b/internal/handlers/tax.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"erp-backend/internal/models"
+	"erp-backend/internal/services"
+	"erp-backend/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TaxHandler handles HTTP requests for taxes
+
+type TaxHandler struct {
+	service *services.TaxService
+}
+
+// NewTaxHandler creates a new TaxHandler
+func NewTaxHandler() *TaxHandler {
+	return &TaxHandler{service: services.NewTaxService()}
+}
+
+// GetTaxes handles GET /taxes
+func (h *TaxHandler) GetTaxes(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	taxes, err := h.service.GetTaxes(companyID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get taxes", err)
+		return
+	}
+	utils.SuccessResponse(c, "Taxes retrieved successfully", taxes)
+}
+
+// CreateTax handles POST /taxes
+func (h *TaxHandler) CreateTax(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	var req models.CreateTaxRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+
+	if err := utils.ValidateStruct(&req); err != nil {
+		utils.ValidationErrorResponse(c, utils.GetValidationErrors(err))
+		return
+	}
+
+	tax, err := h.service.CreateTax(companyID, &req)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to create tax", err)
+		return
+	}
+	utils.CreatedResponse(c, "Tax created successfully", tax)
+}
+
+// UpdateTax handles PUT /taxes/:id
+func (h *TaxHandler) UpdateTax(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid tax ID", err)
+		return
+	}
+
+	var req models.UpdateTaxRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+
+	if err := utils.ValidateStruct(&req); err != nil {
+		utils.ValidationErrorResponse(c, utils.GetValidationErrors(err))
+		return
+	}
+
+	if err := h.service.UpdateTax(id, companyID, &req); err != nil {
+		if err.Error() == "tax not found" {
+			utils.NotFoundResponse(c, "Tax not found")
+			return
+		}
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to update tax", err)
+		return
+	}
+	utils.SuccessResponse(c, "Tax updated successfully", nil)
+}
+
+// DeleteTax handles DELETE /taxes/:id
+func (h *TaxHandler) DeleteTax(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid tax ID", err)
+		return
+	}
+
+	if err := h.service.DeleteTax(id, companyID); err != nil {
+		if err.Error() == "tax not found" {
+			utils.NotFoundResponse(c, "Tax not found")
+			return
+		}
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to delete tax", err)
+		return
+	}
+	utils.SuccessResponse(c, "Tax deleted successfully", nil)
+}

--- a/internal/models/tax.go
+++ b/internal/models/tax.go
@@ -1,0 +1,35 @@
+package models
+
+// Tax represents a tax rate configuration for a company
+// maps to taxes table
+
+type Tax struct {
+	TaxID      int     `json:"tax_id" db:"tax_id"`
+	CompanyID  int     `json:"company_id" db:"company_id"`
+	Name       string  `json:"name" db:"name"`
+	Percentage float64 `json:"percentage" db:"percentage"`
+	IsCompound bool    `json:"is_compound" db:"is_compound"`
+	IsActive   bool    `json:"is_active" db:"is_active"`
+	BaseModel
+}
+
+// CreateTaxRequest represents request body for creating a tax
+// Percentage must be between 0 and 100
+// IsCompound indicates whether tax is calculated on top of other taxes
+
+type CreateTaxRequest struct {
+	Name       string  `json:"name" validate:"required"`
+	Percentage float64 `json:"percentage" validate:"required,gte=0,lte=100"`
+	IsCompound bool    `json:"is_compound"`
+	IsActive   bool    `json:"is_active"`
+}
+
+// UpdateTaxRequest represents request body for updating a tax
+// Fields are optional; only provided fields will be updated
+
+type UpdateTaxRequest struct {
+	Name       *string  `json:"name,omitempty"`
+	Percentage *float64 `json:"percentage,omitempty" validate:"omitempty,gte=0,lte=100"`
+	IsCompound *bool    `json:"is_compound,omitempty"`
+	IsActive   *bool    `json:"is_active,omitempty"`
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -59,6 +59,7 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 	numberingSequenceHandler := handlers.NewNumberingSequenceHandler()
 	invoiceTemplateHandler := handlers.NewInvoiceTemplateHandler()
 	currencyHandler := handlers.NewCurrencyHandler()
+	taxHandler := handlers.NewTaxHandler()
 	// Health check endpoint
 	router.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
@@ -489,6 +490,16 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 				currencies.PUT("/:id", middleware.RequirePermission("MANAGE_SETTINGS"), currencyHandler.UpdateCurrency)
 				currencies.PATCH("/:id", middleware.RequirePermission("MANAGE_SETTINGS"), currencyHandler.UpdateCurrency)
 				currencies.DELETE("/:id", middleware.RequirePermission("MANAGE_SETTINGS"), currencyHandler.DeleteCurrency)
+			}
+
+			// Tax routes
+			taxes := protected.Group("/taxes")
+			taxes.Use(middleware.RequireCompanyAccess())
+			{
+				taxes.GET("", middleware.RequirePermission("MANAGE_SETTINGS"), taxHandler.GetTaxes)
+				taxes.POST("", middleware.RequirePermission("MANAGE_SETTINGS"), taxHandler.CreateTax)
+				taxes.PUT("/:id", middleware.RequirePermission("MANAGE_SETTINGS"), taxHandler.UpdateTax)
+				taxes.DELETE("/:id", middleware.RequirePermission("MANAGE_SETTINGS"), taxHandler.DeleteTax)
 			}
 
 			// Settings routes

--- a/internal/services/tax_service.go
+++ b/internal/services/tax_service.go
@@ -1,0 +1,117 @@
+package services
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"erp-backend/internal/database"
+	"erp-backend/internal/models"
+)
+
+// TaxService provides CRUD operations for taxes
+
+type TaxService struct {
+	db *sql.DB
+}
+
+// NewTaxService creates a new TaxService
+func NewTaxService() *TaxService {
+	return &TaxService{db: database.GetDB()}
+}
+
+// GetTaxes returns all taxes for a company
+func (s *TaxService) GetTaxes(companyID int) ([]models.Tax, error) {
+	rows, err := s.db.Query(`SELECT tax_id, company_id, name, percentage, is_compound, is_active, created_at, updated_at FROM taxes WHERE company_id = $1 ORDER BY name`, companyID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get taxes: %w", err)
+	}
+	defer rows.Close()
+
+	var taxes []models.Tax
+	for rows.Next() {
+		var t models.Tax
+		if err := rows.Scan(&t.TaxID, &t.CompanyID, &t.Name, &t.Percentage, &t.IsCompound, &t.IsActive, &t.CreatedAt, &t.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan tax: %w", err)
+		}
+		taxes = append(taxes, t)
+	}
+	return taxes, nil
+}
+
+// CreateTax creates a new tax
+func (s *TaxService) CreateTax(companyID int, req *models.CreateTaxRequest) (*models.Tax, error) {
+	var tax models.Tax
+	err := s.db.QueryRow(`INSERT INTO taxes (company_id, name, percentage, is_compound, is_active) VALUES ($1,$2,$3,$4,$5) RETURNING tax_id, created_at, updated_at`,
+		companyID, req.Name, req.Percentage, req.IsCompound, req.IsActive).Scan(&tax.TaxID, &tax.CreatedAt, &tax.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tax: %w", err)
+	}
+	tax.CompanyID = companyID
+	tax.Name = req.Name
+	tax.Percentage = req.Percentage
+	tax.IsCompound = req.IsCompound
+	tax.IsActive = req.IsActive
+	return &tax, nil
+}
+
+// UpdateTax updates an existing tax
+func (s *TaxService) UpdateTax(id, companyID int, req *models.UpdateTaxRequest) error {
+	setParts := []string{}
+	args := []interface{}{}
+
+	if req.Name != nil {
+		setParts = append(setParts, fmt.Sprintf("name = $%d", len(args)+1))
+		args = append(args, *req.Name)
+	}
+	if req.Percentage != nil {
+		setParts = append(setParts, fmt.Sprintf("percentage = $%d", len(args)+1))
+		args = append(args, *req.Percentage)
+	}
+	if req.IsCompound != nil {
+		setParts = append(setParts, fmt.Sprintf("is_compound = $%d", len(args)+1))
+		args = append(args, *req.IsCompound)
+	}
+	if req.IsActive != nil {
+		setParts = append(setParts, fmt.Sprintf("is_active = $%d", len(args)+1))
+		args = append(args, *req.IsActive)
+	}
+
+	if len(setParts) == 0 {
+		return fmt.Errorf("no fields to update")
+	}
+
+	setParts = append(setParts, "updated_at = CURRENT_TIMESTAMP")
+	argPos := len(args) + 1
+	query := fmt.Sprintf("UPDATE taxes SET %s WHERE tax_id = $%d AND company_id = $%d", strings.Join(setParts, ", "), argPos, argPos+1)
+	args = append(args, id, companyID)
+
+	res, err := s.db.Exec(query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to update tax: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("tax not found")
+	}
+	return nil
+}
+
+// DeleteTax deletes a tax
+func (s *TaxService) DeleteTax(id, companyID int) error {
+	res, err := s.db.Exec(`DELETE FROM taxes WHERE tax_id = $1 AND company_id = $2`, id, companyID)
+	if err != nil {
+		return fmt.Errorf("failed to delete tax: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("tax not found")
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- implement tax model with validation for percentage and compound flag
- add TaxService and TaxHandler for CRUD operations
- register /taxes routes requiring MANAGE_SETTINGS permission

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0bd94192c832ca8d6356a76203b00