### PR TITLE
Add user preference management endpoints

### DIFF
--- a/internal/handlers/user_preferences.go
+++ b/internal/handlers/user_preferences.go
@@ -1,0 +1,77 @@
+package handlers
+
+import (
+	"net/http"
+
+	"erp-backend/internal/services"
+	"erp-backend/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+type UserPreferencesHandler struct {
+	service *services.UserPreferencesService
+}
+
+func NewUserPreferencesHandler() *UserPreferencesHandler {
+	return &UserPreferencesHandler{service: services.NewUserPreferencesService()}
+}
+
+func (h *UserPreferencesHandler) GetPreferences(c *gin.Context) {
+	userID := c.GetInt("user_id")
+	if userID == 0 {
+		utils.UnauthorizedResponse(c, "User context not found")
+		return
+	}
+	prefs, err := h.service.GetPreferences(userID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get preferences", err)
+		return
+	}
+	utils.SuccessResponse(c, "Preferences retrieved successfully", prefs)
+}
+
+type UserPreferenceRequest struct {
+	Key   string `json:"key" validate:"required"`
+	Value string `json:"value"`
+}
+
+func (h *UserPreferencesHandler) UpsertPreference(c *gin.Context) {
+	userID := c.GetInt("user_id")
+	if userID == 0 {
+		utils.UnauthorizedResponse(c, "User context not found")
+		return
+	}
+	var req UserPreferenceRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	if err := utils.ValidateStruct(&req); err != nil {
+		utils.ValidationErrorResponse(c, utils.GetValidationErrors(err))
+		return
+	}
+	if err := h.service.UpsertPreference(userID, req.Key, req.Value); err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to upsert preference", err)
+		return
+	}
+	utils.SuccessResponse(c, "Preference saved successfully", nil)
+}
+
+func (h *UserPreferencesHandler) DeletePreference(c *gin.Context) {
+	userID := c.GetInt("user_id")
+	if userID == 0 {
+		utils.UnauthorizedResponse(c, "User context not found")
+		return
+	}
+	key := c.Param("key")
+	if key == "" {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Preference key required", nil)
+		return
+	}
+	if err := h.service.DeletePreference(userID, key); err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to delete preference", err)
+		return
+	}
+	utils.SuccessResponse(c, "Preference deleted successfully", nil)
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -25,21 +25,22 @@ type User struct {
 }
 
 type UserResponse struct {
-	UserID            int        `json:"user_id"`
-	Username          string     `json:"username"`
-	Email             string     `json:"email"`
-	FirstName         *string    `json:"first_name,omitempty"`
-	LastName          *string    `json:"last_name,omitempty"`
-	Phone             *string    `json:"phone,omitempty"`
-	RoleID            *int       `json:"role_id,omitempty"` // CHANGE: int -> *int
-	LocationID        *int       `json:"location_id,omitempty"`
-	CompanyID         *int       `json:"company_id,omitempty"` // CHANGE: int -> *int
-	IsActive          bool       `json:"is_active"`
-	IsLocked          bool       `json:"is_locked"`
-	PreferredLanguage *string    `json:"preferred_language,omitempty"`
-	SecondaryLanguage *string    `json:"secondary_language,omitempty"`
-	LastLogin         *time.Time `json:"last_login,omitempty"`
-	Permissions       []string   `json:"permissions,omitempty"`
+	UserID            int               `json:"user_id"`
+	Username          string            `json:"username"`
+	Email             string            `json:"email"`
+	FirstName         *string           `json:"first_name,omitempty"`
+	LastName          *string           `json:"last_name,omitempty"`
+	Phone             *string           `json:"phone,omitempty"`
+	RoleID            *int              `json:"role_id,omitempty"` // CHANGE: int -> *int
+	LocationID        *int              `json:"location_id,omitempty"`
+	CompanyID         *int              `json:"company_id,omitempty"` // CHANGE: int -> *int
+	IsActive          bool              `json:"is_active"`
+	IsLocked          bool              `json:"is_locked"`
+	PreferredLanguage *string           `json:"preferred_language,omitempty"`
+	SecondaryLanguage *string           `json:"secondary_language,omitempty"`
+	LastLogin         *time.Time        `json:"last_login,omitempty"`
+	Permissions       []string          `json:"permissions,omitempty"`
+	Preferences       map[string]string `json:"preferences,omitempty"`
 }
 type CreateUserRequest struct {
 	Username          string  `json:"username" validate:"required,min=3,max=50"`

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -60,6 +60,7 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 	invoiceTemplateHandler := handlers.NewInvoiceTemplateHandler()
 	currencyHandler := handlers.NewCurrencyHandler()
 	taxHandler := handlers.NewTaxHandler()
+	userPreferencesHandler := handlers.NewUserPreferencesHandler()
 	// Health check endpoint
 	router.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
@@ -557,6 +558,15 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 			{
 				translations.GET("", middleware.RequirePermission("VIEW_TRANSLATIONS"), translationHandler.GetTranslations)
 				translations.PUT("", middleware.RequirePermission("MANAGE_TRANSLATIONS"), translationHandler.UpdateTranslations)
+			}
+
+			// User preferences routes
+			userPrefs := protected.Group("/user-preferences")
+			{
+				userPrefs.GET("", userPreferencesHandler.GetPreferences)
+				userPrefs.PUT("", userPreferencesHandler.UpsertPreference)
+				userPrefs.PATCH("", userPreferencesHandler.UpsertPreference)
+				userPrefs.DELETE("/:key", userPreferencesHandler.DeletePreference)
 			}
 
 			// Numbering sequence routes

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -120,6 +120,12 @@ func (s *AuthService) Login(req *models.LoginRequest, ipAddress, userAgent strin
 		permissions = []string{}
 	}
 
+	prefsSvc := NewUserPreferencesService()
+	prefs, err := prefsSvc.GetPreferences(user.UserID)
+	if err != nil {
+		prefs = map[string]string{}
+	}
+
 	userResponse := models.UserResponse{
 		UserID:            user.UserID,
 		Username:          user.Username,
@@ -136,6 +142,7 @@ func (s *AuthService) Login(req *models.LoginRequest, ipAddress, userAgent strin
 		SecondaryLanguage: user.SecondaryLanguage,
 		LastLogin:         user.LastLogin,
 		Permissions:       permissions,
+		Preferences:       prefs,
 	}
 
 	return &models.LoginResponse{
@@ -262,6 +269,12 @@ func (s *AuthService) GetMe(userID int) (*models.UserResponse, error) {
 		permissions = []string{}
 	}
 
+	prefsSvc := NewUserPreferencesService()
+	prefs, err := prefsSvc.GetPreferences(userID)
+	if err != nil {
+		prefs = map[string]string{}
+	}
+
 	return &models.UserResponse{
 		UserID:            user.UserID,
 		Username:          user.Username,
@@ -278,6 +291,7 @@ func (s *AuthService) GetMe(userID int) (*models.UserResponse, error) {
 		SecondaryLanguage: user.SecondaryLanguage,
 		LastLogin:         user.LastLogin,
 		Permissions:       permissions,
+		Preferences:       prefs,
 	}, nil
 }
 

--- a/internal/services/user_preferences_service.go
+++ b/internal/services/user_preferences_service.go
@@ -1,0 +1,45 @@
+package services
+
+import (
+	"database/sql"
+
+	"erp-backend/internal/database"
+)
+
+type UserPreferencesService struct {
+	db *sql.DB
+}
+
+func NewUserPreferencesService() *UserPreferencesService {
+	return &UserPreferencesService{db: database.GetDB()}
+}
+
+func (s *UserPreferencesService) GetPreferences(userID int) (map[string]string, error) {
+	query := `SELECT key, value FROM user_preferences WHERE user_id=$1`
+	rows, err := s.db.Query(query, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	prefs := make(map[string]string)
+	for rows.Next() {
+		var key, value string
+		if err := rows.Scan(&key, &value); err != nil {
+			return nil, err
+		}
+		prefs[key] = value
+	}
+	return prefs, nil
+}
+
+func (s *UserPreferencesService) UpsertPreference(userID int, key, value string) error {
+	query := `INSERT INTO user_preferences (user_id, key, value) VALUES ($1,$2,$3)
+              ON CONFLICT (user_id, key) DO UPDATE SET value=EXCLUDED.value`
+	_, err := s.db.Exec(query, userID, key, value)
+	return err
+}
+
+func (s *UserPreferencesService) DeletePreference(userID int, key string) error {
+	_, err := s.db.Exec(`DELETE FROM user_preferences WHERE user_id=$1 AND key=$2`, userID, key)
+	return err
+}


### PR DESCRIPTION
## Summary
- support storing per-user key/value preferences with service layer
- expose `/api/v1/user-preferences` endpoints for retrieval, upsert, and deletion
- include stored preferences in authentication profile responses

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0befcc440832cb9abbd8b68476cb5