### PR TITLE
Track device session activity via JWT

### DIFF
--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"database/sql"
+	"log"
 	"net/http"
 
 	"erp-backend/internal/database"
@@ -123,6 +124,27 @@ func RequireAuth() gin.HandlerFunc {
 			c.Set("role_id", *claims.RoleID)
 		}
 		c.Set("user", user)
+
+		// Update device session activity if session ID is present
+		if claims.SessionID != "" {
+			db := database.GetDB()
+			ipAddr := c.ClientIP()
+			ua := c.GetHeader("User-Agent")
+			var ipVal interface{}
+			if ipAddr != "" {
+				ipVal = ipAddr
+			}
+			var uaVal interface{}
+			if ua != "" {
+				uaVal = ua
+			}
+			_, err := db.Exec(`UPDATE device_sessions SET last_seen = NOW(), ip_address = COALESCE($2, ip_address), user_agent = COALESCE($3, user_agent) WHERE session_id = $1`, claims.SessionID, ipVal, uaVal)
+			if err != nil {
+				log.Printf("Failed to update device session %s: %v", claims.SessionID, err)
+			}
+		} else {
+			log.Println("No session ID in JWT claims")
+		}
 
 		c.Next()
 	}

--- a/internal/models/auth.go
+++ b/internal/models/auth.go
@@ -39,6 +39,7 @@ type ChangePasswordRequest struct {
 }
 
 type JWTClaims struct {
+	SessionID  string `json:"session_id,omitempty"`
 	UserID     int    `json:"user_id"`
 	CompanyID  *int   `json:"company_id,omitempty"` // CHANGE: int -> *int
 	LocationID *int   `json:"location_id,omitempty"`

--- a/internal/utils/jwt.go
+++ b/internal/utils/jwt.go
@@ -22,9 +22,10 @@ func InitializeJWT(secret string) {
 }
 
 // GenerateAccessToken creates a new access token
-func GenerateAccessToken(user *models.User, expiry time.Duration) (string, error) {
+func GenerateAccessToken(user *models.User, sessionID string, expiry time.Duration) (string, error) {
 	claims := &Claims{
 		JWTClaims: models.JWTClaims{
+			SessionID:  sessionID,
 			UserID:     user.UserID,
 			CompanyID:  user.CompanyID,
 			LocationID: user.LocationID,
@@ -44,9 +45,10 @@ func GenerateAccessToken(user *models.User, expiry time.Duration) (string, error
 }
 
 // GenerateRefreshToken creates a new refresh token
-func GenerateRefreshToken(user *models.User, expiry time.Duration) (string, error) {
+func GenerateRefreshToken(user *models.User, sessionID string, expiry time.Duration) (string, error) {
 	claims := &Claims{
 		JWTClaims: models.JWTClaims{
+			SessionID:  sessionID,
 			UserID:     user.UserID,
 			CompanyID:  user.CompanyID,
 			LocationID: user.LocationID,


### PR DESCRIPTION
## Summary
- include session_id in JWT claims and token generation
- refresh device session metadata (last_seen, IP, user agent) on authenticated requests
- pass session identifiers through login and refresh flows

## Testing
- `go build ./internal/middleware`
- `go build ./internal/utils`
- `go build ./internal/services`


------
https://chatgpt.com/codex/tasks/task_e_68a0c16e95a8832cb15dae36824efaa7