### PR TITLE
Add supplier summary view and service methods

### DIFF
--- a/internal/handlers/supplier.go
+++ b/internal/handlers/supplier.go
@@ -74,6 +74,29 @@ func (h *SupplierHandler) GetSupplier(c *gin.Context) {
 	utils.SuccessResponse(c, "Supplier retrieved successfully", supplier)
 }
 
+// GET /suppliers/:id/summary
+func (h *SupplierHandler) GetSupplierSummary(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	supplierID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid supplier ID", err)
+		return
+	}
+
+	summary, err := h.supplierService.GetSupplierSummary(supplierID, companyID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get supplier summary", err)
+		return
+	}
+
+	utils.SuccessResponse(c, "Supplier summary retrieved successfully", summary)
+}
+
 // POST /suppliers
 func (h *SupplierHandler) CreateSupplier(c *gin.Context) {
 	companyID := c.GetInt("company_id")

--- a/internal/models/supplier.go
+++ b/internal/models/supplier.go
@@ -29,6 +29,15 @@ type SupplierWithStats struct {
 	LastPurchaseDate  *time.Time `json:"last_purchase_date,omitempty"`
 }
 
+type SupplierSummary struct {
+	SupplierID         int     `json:"supplier_id"`
+	CompanyID          int     `json:"company_id"`
+	TotalPurchases     float64 `json:"total_purchases"`
+	TotalPayments      float64 `json:"total_payments"`
+	TotalReturns       float64 `json:"total_returns"`
+	OutstandingBalance float64 `json:"outstanding_balance"`
+}
+
 // Request Models
 type CreateSupplierRequest struct {
 	Name          string   `json:"name" validate:"required,min=2,max=255"`

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -477,6 +477,8 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 			{
 				suppliers.GET("", middleware.RequirePermission("VIEW_SUPPLIERS"), supplierHandler.GetSuppliers)
 				suppliers.GET("/:id", middleware.RequirePermission("VIEW_SUPPLIERS"), supplierHandler.GetSupplier)
+
+				suppliers.GET("/:id/summary", middleware.RequirePermission("VIEW_SUPPLIERS"), supplierHandler.GetSupplierSummary)
 				suppliers.POST("", middleware.RequirePermission("CREATE_SUPPLIERS"), supplierHandler.CreateSupplier)
 				suppliers.PUT("/:id", middleware.RequirePermission("UPDATE_SUPPLIERS"), supplierHandler.UpdateSupplier)
 				suppliers.DELETE("/:id", middleware.RequirePermission("DELETE_SUPPLIERS"), supplierHandler.DeleteSupplier)

--- a/migrations/003_create_supplier_summary_view.sql
+++ b/migrations/003_create_supplier_summary_view.sql
@@ -1,0 +1,18 @@
+-- Create view to aggregate supplier purchases, payments, returns and outstanding balance
+CREATE OR REPLACE VIEW supplier_summary AS
+SELECT s.supplier_id,
+       s.company_id,
+       COALESCE(SUM(p.total_amount), 0) AS total_purchases,
+       COALESCE(SUM(pay.amount), 0) AS total_payments,
+       COALESCE(SUM(pr.total_amount), 0) AS total_returns,
+       COALESCE(SUM(p.total_amount), 0) - COALESCE(SUM(pay.amount), 0) - COALESCE(SUM(pr.total_amount), 0) AS outstanding_balance
+FROM suppliers s
+LEFT JOIN purchases p ON p.supplier_id = s.supplier_id AND p.is_deleted = FALSE
+LEFT JOIN payments pay ON pay.supplier_id = s.supplier_id AND pay.is_deleted = FALSE
+LEFT JOIN purchase_returns pr ON pr.supplier_id = s.supplier_id AND pr.is_deleted = FALSE
+GROUP BY s.supplier_id, s.company_id;
+
+-- Indexes to support supplier_summary view
+CREATE INDEX IF NOT EXISTS idx_purchases_supplier ON purchases(supplier_id);
+CREATE INDEX IF NOT EXISTS idx_purchase_returns_supplier ON purchase_returns(supplier_id);
+CREATE INDEX IF NOT EXISTS idx_payments_supplier ON payments(supplier_id);


### PR DESCRIPTION
## Summary
- create `supplier_summary` SQL view and supporting indexes
- add SupplierSummary model, service methods, handler and route using the view

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a1f60313d4832c9989053f3efe77c7