### PR TITLE
feat: add ledger entries retrieval

### DIFF
--- a/internal/handlers/ledger.go
+++ b/internal/handlers/ledger.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"net/http"
+	"strconv"
 
+	"erp-backend/internal/models"
 	"erp-backend/internal/services"
 	"erp-backend/internal/utils"
 
@@ -27,4 +29,38 @@ func (h *LedgerHandler) GetBalances(c *gin.Context) {
 		return
 	}
 	utils.SuccessResponse(c, "Ledger balances retrieved", balances)
+}
+
+// GET /ledgers/:account_id/entries
+func (h *LedgerHandler) GetEntries(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	accountID, err := strconv.Atoi(c.Param("account_id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid account ID", err)
+		return
+	}
+
+	filters := map[string]string{}
+	if v := c.Query("date_from"); v != "" {
+		filters["date_from"] = v
+	}
+	if v := c.Query("date_to"); v != "" {
+		filters["date_to"] = v
+	}
+
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	perPage, _ := strconv.Atoi(c.DefaultQuery("per_page", "20"))
+
+	entries, total, err := h.service.GetAccountEntries(companyID, accountID, filters, page, perPage)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get ledger entries", err)
+		return
+	}
+
+	totalPages := 0
+	if perPage > 0 {
+		totalPages = (total + perPage - 1) / perPage
+	}
+	meta := &models.Meta{Page: page, PerPage: perPage, Total: total, TotalPages: totalPages}
+	utils.PaginatedResponse(c, "Ledger entries retrieved", entries, meta)
 }

--- a/internal/models/ledger.go
+++ b/internal/models/ledger.go
@@ -1,16 +1,30 @@
 package models
 
+import "time"
+
 type LedgerEntry struct {
-	EntryID     int     `json:"entry_id" db:"entry_id"`
-	CompanyID   int     `json:"company_id" db:"company_id"`
-	AccountID   int     `json:"account_id" db:"account_id"`
-	Debit       float64 `json:"debit" db:"debit"`
-	Credit      float64 `json:"credit" db:"credit"`
-	Reference   string  `json:"reference" db:"reference"`
-	Description *string `json:"description,omitempty" db:"description"`
-	CreatedBy   int     `json:"created_by" db:"created_by"`
-	UpdatedBy   *int    `json:"updated_by,omitempty" db:"updated_by"`
+	EntryID         int       `json:"entry_id" db:"entry_id"`
+	CompanyID       int       `json:"company_id" db:"company_id"`
+	AccountID       int       `json:"account_id" db:"account_id"`
+	VoucherID       *int      `json:"voucher_id,omitempty" db:"voucher_id"`
+	Date            time.Time `json:"date" db:"date"`
+	Debit           float64   `json:"debit" db:"debit"`
+	Credit          float64   `json:"credit" db:"credit"`
+	Balance         float64   `json:"balance" db:"balance"`
+	TransactionType *string   `json:"transaction_type,omitempty" db:"transaction_type"`
+	TransactionID   *int      `json:"transaction_id,omitempty" db:"transaction_id"`
+	Description     *string   `json:"description,omitempty" db:"description"`
+	CreatedBy       int       `json:"created_by" db:"created_by"`
+	UpdatedBy       *int      `json:"updated_by,omitempty" db:"updated_by"`
 	SyncModel
+}
+
+// LedgerEntryWithDetails represents a ledger entry with related transaction information
+type LedgerEntryWithDetails struct {
+	LedgerEntry
+	Voucher  *Voucher  `json:"voucher,omitempty"`
+	Sale     *Sale     `json:"sale,omitempty"`
+	Purchase *Purchase `json:"purchase,omitempty"`
 }
 
 type AccountBalance struct {

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -442,6 +442,7 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 			ledgers.Use(middleware.RequireCompanyAccess())
 			{
 				ledgers.GET("", middleware.RequirePermission("VIEW_LEDGER"), ledgerHandler.GetBalances)
+				ledgers.GET("/:account_id/entries", middleware.RequirePermission("VIEW_LEDGER_DETAILS"), ledgerHandler.GetEntries)
 			}
 
 			cashRegisters := protected.Group("/cash-registers")

--- a/internal/services/ledger_service.go
+++ b/internal/services/ledger_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"database/sql"
+	"fmt"
 
 	"erp-backend/internal/database"
 	"erp-backend/internal/models"
@@ -49,4 +50,142 @@ func (s *LedgerService) GetAccountBalances(companyID int) ([]models.AccountBalan
 		balances = append(balances, b)
 	}
 	return balances, nil
+}
+
+// GetAccountEntries retrieves ledger entries for an account with optional filters and pagination
+func (s *LedgerService) GetAccountEntries(companyID, accountID int, filters map[string]string, page, pageSize int) ([]models.LedgerEntryWithDetails, int, error) {
+	baseQuery := `SELECT le.entry_id, le.company_id, le.account_id, le.voucher_id, le.date, le.debit, le.credit, le.balance, le.transaction_type, le.transaction_id, le.description, le.created_by, le.updated_by, le.sync_status, le.created_at, le.updated_at,
+                v.type, v.amount, v.reference, v.description,
+                s.sale_id, s.sale_number, s.total_amount, s.sale_date,
+                p.purchase_id, p.purchase_number, p.total_amount, p.purchase_date
+                FROM ledger_entries le
+                LEFT JOIN vouchers v ON le.voucher_id = v.voucher_id AND v.is_deleted = FALSE
+                LEFT JOIN sales s ON le.transaction_type = 'sale' AND le.transaction_id = s.sale_id
+                LEFT JOIN purchases p ON le.transaction_type = 'purchase' AND le.transaction_id = p.purchase_id
+                WHERE le.company_id = $1 AND le.account_id = $2`
+
+	countQuery := `SELECT COUNT(*) FROM ledger_entries le WHERE le.company_id = $1 AND le.account_id = $2`
+
+	args := []interface{}{companyID, accountID}
+	countArgs := []interface{}{companyID, accountID}
+	argPos := 2
+
+	if v, ok := filters["date_from"]; ok && v != "" {
+		argPos++
+		baseQuery += fmt.Sprintf(" AND le.date >= $%d", argPos)
+		countQuery += fmt.Sprintf(" AND le.date >= $%d", argPos)
+		args = append(args, v)
+		countArgs = append(countArgs, v)
+	}
+	if v, ok := filters["date_to"]; ok && v != "" {
+		argPos++
+		baseQuery += fmt.Sprintf(" AND le.date <= $%d", argPos)
+		countQuery += fmt.Sprintf(" AND le.date <= $%d", argPos)
+		args = append(args, v)
+		countArgs = append(countArgs, v)
+	}
+
+	var total int
+	if err := s.db.QueryRow(countQuery, countArgs...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("failed to count ledger entries: %w", err)
+	}
+
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	if page <= 0 {
+		page = 1
+	}
+	offset := (page - 1) * pageSize
+	baseQuery += fmt.Sprintf(" ORDER BY le.date DESC, le.entry_id DESC LIMIT $%d OFFSET $%d", argPos+1, argPos+2)
+	args = append(args, pageSize, offset)
+
+	rows, err := s.db.Query(baseQuery, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get ledger entries: %w", err)
+	}
+	defer rows.Close()
+
+	var entries []models.LedgerEntryWithDetails
+	for rows.Next() {
+		var e models.LedgerEntryWithDetails
+		var voucherType, voucherRef, voucherDesc sql.NullString
+		var voucherAmount sql.NullFloat64
+		var saleID sql.NullInt64
+		var saleNumber sql.NullString
+		var saleAmount sql.NullFloat64
+		var saleDate sql.NullTime
+		var purchaseID sql.NullInt64
+		var purchaseNumber sql.NullString
+		var purchaseAmount sql.NullFloat64
+		var purchaseDate sql.NullTime
+		var transactionType, description sql.NullString
+		var transactionID, updatedBy sql.NullInt64
+		var voucherID sql.NullInt64
+
+		if err := rows.Scan(
+			&e.EntryID, &e.CompanyID, &e.AccountID, &voucherID, &e.Date, &e.Debit, &e.Credit, &e.Balance, &transactionType, &transactionID, &description, &e.CreatedBy, &updatedBy, &e.SyncStatus, &e.CreatedAt, &e.UpdatedAt,
+			&voucherType, &voucherAmount, &voucherRef, &voucherDesc,
+			&saleID, &saleNumber, &saleAmount, &saleDate,
+			&purchaseID, &purchaseNumber, &purchaseAmount, &purchaseDate,
+		); err != nil {
+			return nil, 0, fmt.Errorf("failed to scan ledger entry: %w", err)
+		}
+
+		if voucherID.Valid {
+			v := int(voucherID.Int64)
+			e.VoucherID = &v
+		}
+		if transactionType.Valid {
+			e.TransactionType = &transactionType.String
+		}
+		if transactionID.Valid {
+			id := int(transactionID.Int64)
+			e.TransactionID = &id
+		}
+		if description.Valid {
+			e.Description = &description.String
+		}
+		if updatedBy.Valid {
+			u := int(updatedBy.Int64)
+			e.UpdatedBy = &u
+		}
+
+		if voucherType.Valid {
+			e.Voucher = &models.Voucher{
+				VoucherID:   0,
+				Type:        voucherType.String,
+				Amount:      voucherAmount.Float64,
+				Reference:   voucherRef.String,
+				Description: nullStringToStringPtr(voucherDesc),
+			}
+			if e.VoucherID != nil {
+				e.Voucher.VoucherID = *e.VoucherID
+			}
+		}
+		if saleID.Valid {
+			e.Sale = &models.Sale{
+				SaleID:      int(saleID.Int64),
+				SaleNumber:  saleNumber.String,
+				TotalAmount: saleAmount.Float64,
+			}
+			if saleDate.Valid {
+				e.Sale.SaleDate = saleDate.Time
+			}
+		}
+		if purchaseID.Valid {
+			e.Purchase = &models.Purchase{
+				PurchaseID:     int(purchaseID.Int64),
+				PurchaseNumber: purchaseNumber.String,
+				TotalAmount:    purchaseAmount.Float64,
+			}
+			if purchaseDate.Valid {
+				e.Purchase.PurchaseDate = purchaseDate.Time
+			}
+		}
+
+		entries = append(entries, e)
+	}
+
+	return entries, total, nil
 }


### PR DESCRIPTION
## Summary
- add API handler for listing ledger entries by account with pagination and date filters
- query ledger entries with voucher, sale, and purchase context
- expose new `GET /ledgers/:account_id/entries` route with `VIEW_LEDGER_DETAILS` permission

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a20441c4cc832cb3efab5607e8961c