### PR TITLE
Add audit fields to expense categories

### DIFF
--- a/Docs & Schema/PostgrSQL.sql
+++ b/Docs & Schema/PostgrSQL.sql
@@ -311,7 +311,9 @@ CREATE TABLE expense_categories (
     company_id INTEGER NOT NULL REFERENCES companies(company_id) ON DELETE CASCADE,
     name VARCHAR(255) NOT NULL,
     description TEXT,
-    is_active BOOLEAN DEFAULT TRUE
+    is_active BOOLEAN DEFAULT TRUE,
+    created_by INTEGER NOT NULL REFERENCES users(user_id),
+    updated_by INTEGER REFERENCES users(user_id)
 );
 
 -- ===============================================

--- a/internal/handlers/expense.go
+++ b/internal/handlers/expense.go
@@ -102,6 +102,7 @@ func (h *ExpenseHandler) GetCategories(c *gin.Context) {
 // POST /expenses/categories
 func (h *ExpenseHandler) CreateCategory(c *gin.Context) {
 	companyID := c.GetInt("company_id")
+	userID := c.GetInt("user_id")
 
 	var req models.CreateExpenseCategoryRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -114,7 +115,7 @@ func (h *ExpenseHandler) CreateCategory(c *gin.Context) {
 		return
 	}
 
-	id, err := h.service.CreateCategory(companyID, req.Name)
+	id, err := h.service.CreateCategory(companyID, userID, req.Name)
 	if err != nil {
 		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to create category", err)
 		return

--- a/internal/models/expense.go
+++ b/internal/models/expense.go
@@ -24,6 +24,8 @@ type ExpenseWithDetails struct {
 type ExpenseCategory struct {
 	CategoryID int    `json:"category_id" db:"category_id"`
 	Name       string `json:"name" db:"name"`
+	CreatedBy  int    `json:"created_by" db:"created_by"`
+	UpdatedBy  *int   `json:"updated_by,omitempty" db:"updated_by"`
 	SyncModel
 }
 

--- a/internal/services/expense_service.go
+++ b/internal/services/expense_service.go
@@ -30,7 +30,7 @@ func (s *ExpenseService) CreateExpense(companyID, locationID, userID int, req *m
 }
 
 func (s *ExpenseService) GetCategories(companyID int) ([]models.ExpenseCategory, error) {
-	rows, err := s.db.Query(`SELECT category_id, name FROM expense_categories WHERE company_id=$1 AND is_deleted=FALSE`, companyID)
+	rows, err := s.db.Query(`SELECT category_id, name, created_by, updated_by FROM expense_categories WHERE company_id=$1 AND is_deleted=FALSE`, companyID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get categories: %w", err)
 	}
@@ -38,7 +38,7 @@ func (s *ExpenseService) GetCategories(companyID int) ([]models.ExpenseCategory,
 	var cats []models.ExpenseCategory
 	for rows.Next() {
 		var c models.ExpenseCategory
-		if err := rows.Scan(&c.CategoryID, &c.Name); err != nil {
+		if err := rows.Scan(&c.CategoryID, &c.Name, &c.CreatedBy, &c.UpdatedBy); err != nil {
 			return nil, fmt.Errorf("failed to scan category: %w", err)
 		}
 		cats = append(cats, c)
@@ -46,9 +46,9 @@ func (s *ExpenseService) GetCategories(companyID int) ([]models.ExpenseCategory,
 	return cats, nil
 }
 
-func (s *ExpenseService) CreateCategory(companyID int, name string) (int, error) {
+func (s *ExpenseService) CreateCategory(companyID, userID int, name string) (int, error) {
 	var id int
-	err := s.db.QueryRow(`INSERT INTO expense_categories (company_id, name) VALUES ($1,$2) RETURNING category_id`, companyID, name).Scan(&id)
+	err := s.db.QueryRow(`INSERT INTO expense_categories (company_id, name, created_by, updated_by) VALUES ($1,$2,$3,$3) RETURNING category_id`, companyID, name, userID).Scan(&id)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create category: %w", err)
 	}

--- a/migrations/005_add_created_updated_by_to_expense_categories.sql
+++ b/migrations/005_add_created_updated_by_to_expense_categories.sql
@@ -1,0 +1,6 @@
+ALTER TABLE expense_categories
+    ADD COLUMN created_by INTEGER REFERENCES users(user_id);
+ALTER TABLE expense_categories
+    ADD COLUMN updated_by INTEGER REFERENCES users(user_id);
+UPDATE expense_categories SET created_by = 1, updated_by = 1 WHERE created_by IS NULL;
+ALTER TABLE expense_categories ALTER COLUMN created_by SET NOT NULL;


### PR DESCRIPTION
## Summary
- add `created_by` and `updated_by` columns to `expense_categories`
- update expense category model and service to handle audit fields
- add migration for existing records

## Testing
- `go test -v ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a209add908832cb39e87d53fcdaff5