### PR TITLE
Remove db parameter from routes initialization

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -23,8 +23,7 @@ func main() {
 	cfg := config.Load()
 
 	// Initialize database
-	db, err := database.Initialize(cfg.DatabaseURL)
-	if err != nil {
+	if _, err := database.Initialize(cfg.DatabaseURL); err != nil {
 		log.Fatal("Failed to connect to database:", err)
 	}
 	defer database.Close()
@@ -43,7 +42,7 @@ func main() {
 	router.Use(middleware.CORS())
 
 	// Initialize routes
-	routes.Initialize(router, db.DB) // assuming db has a field or method named DB of type *sql.DB
+	routes.Initialize(router)
 
 	// Start server
 	port := os.Getenv("PORT")

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -1,7 +1,6 @@
 package routes
 
 import (
-	"database/sql"
 	"net/http"
 
 	"erp-backend/internal/config"
@@ -12,7 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func Initialize(router *gin.Engine, db *sql.DB) {
+func Initialize(router *gin.Engine) {
 	cfg := config.Load()
 
 	// Initialize JWT utils


### PR DESCRIPTION
## Summary
- remove `*sql.DB` parameter from `routes.Initialize`
- update server startup to initialize routes without explicit DB

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a20d003220832c813a8ecca3a40f53