### PR TITLE
Use streaming parser for inventory import

### DIFF
--- a/internal/handlers/inventory.go
+++ b/internal/handlers/inventory.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"io"
 	"net/http"
 	"strconv"
 
@@ -260,12 +259,7 @@ func (h *InventoryHandler) ImportInventory(c *gin.Context) {
 		return
 	}
 	defer f.Close()
-	data, err := io.ReadAll(f)
-	if err != nil {
-		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to read file", err)
-		return
-	}
-	if err := h.inventoryService.ImportInventory(companyID, data); err != nil {
+	if err := h.inventoryService.ImportInventory(companyID, f); err != nil {
 		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to import inventory", err)
 		return
 	}

--- a/internal/services/inventory_service.go
+++ b/internal/services/inventory_service.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"database/sql"
+	"encoding/csv"
 	"fmt"
+	"io"
 	"time"
 
 	"erp-backend/internal/database"
@@ -638,9 +640,32 @@ func (s *InventoryService) GetProductSummary(companyID, productID int) (*models.
 	return summary, nil
 }
 
-// ImportInventory processes inventory data from an uploaded file
-func (s *InventoryService) ImportInventory(companyID int, data []byte) error {
-	// Placeholder implementation - in real code this would parse the Excel data
+// ImportInventory processes inventory data from an uploaded file stream
+func (s *InventoryService) ImportInventory(companyID int, r io.Reader) error {
+	reader := csv.NewReader(r)
+
+	// Attempt to read header row; if file is empty just return
+	if _, err := reader.Read(); err != nil {
+		if err == io.EOF {
+			return nil
+		}
+		return fmt.Errorf("failed to read header: %w", err)
+	}
+
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read record: %w", err)
+		}
+
+		// Process each record here. Actual implementation would map
+		// CSV columns to inventory fields and persist them.
+		_ = record
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- stream inventory file instead of reading entirely in the handler
- parse uploaded inventory data row-by-row in `InventoryService.ImportInventory`

## Testing
- `go test ./...` *(fails: command hung while downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a20e723294832c97ca266e316612e5