### PR TITLE
Add attendance records endpoint

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -391,6 +391,7 @@ func Initialize(router *gin.Engine) {
 				attendance.POST("/check-out", middleware.RequirePermission("MANAGE_ATTENDANCE"), attendanceHandler.CheckOut)
 				attendance.POST("/leave", middleware.RequirePermission("MANAGE_ATTENDANCE"), attendanceHandler.ApplyLeave)
 				attendance.GET("/holidays", middleware.RequirePermission("VIEW_ATTENDANCE"), attendanceHandler.GetHolidays)
+				attendance.GET("/records", middleware.RequirePermission("VIEW_ATTENDANCE"), attendanceHandler.GetAttendanceRecords)
 			}
 
 			// Payroll routes (require company)


### PR DESCRIPTION
## Summary
- add `GET /attendance/records` route
- implement attendance records handler with employee and date filters
- add service method to query attendance records

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a213e966b8832c89756c0e9e53f323