### PR TITLE
Add update and delete endpoints for purchase returns

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -358,6 +358,8 @@ func Initialize(router *gin.Engine) {
 				purchaseReturns.GET("", middleware.RequirePermission("VIEW_PURCHASE_RETURNS"), purchaseHandler.GetPurchaseReturns)
 				purchaseReturns.GET("/:id", middleware.RequirePermission("VIEW_PURCHASE_RETURNS"), purchaseHandler.GetPurchaseReturn)
 				purchaseReturns.POST("", middleware.RequirePermission("CREATE_PURCHASE_RETURNS"), purchaseHandler.CreatePurchaseReturn)
+				purchaseReturns.PUT("/:id", middleware.RequirePermission("UPDATE_PURCHASE_RETURNS"), purchaseHandler.UpdatePurchaseReturn)
+				purchaseReturns.DELETE("/:id", middleware.RequirePermission("DELETE_PURCHASE_RETURNS"), purchaseHandler.DeletePurchaseReturn)
 			}
 
 			// Customer management routes (require company)


### PR DESCRIPTION
## Summary
- expose PUT and DELETE routes for purchase return management
- add handler methods for updating and deleting purchase returns
- implement service layer update and delete logic with validation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a2156caad4832c85ca98316a568619