### PR TITLE
Add stock transfer approval endpoint

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -227,6 +227,7 @@ func Initialize(router *gin.Engine) {
 				inventory.GET("/transfers", middleware.RequirePermission("VIEW_INVENTORY"), inventoryHandler.GetStockTransfers)
 				inventory.GET("/transfers/:id", middleware.RequirePermission("VIEW_INVENTORY"), inventoryHandler.GetStockTransfer)
 				inventory.POST("/transfers", middleware.RequirePermission("CREATE_TRANSFERS"), inventoryHandler.CreateStockTransfer)
+				inventory.PUT("/transfers/:id/approve", middleware.RequirePermission("APPROVE_TRANSFERS"), inventoryHandler.ApproveStockTransfer)
 				inventory.PUT("/transfers/:id/complete", middleware.RequirePermission("APPROVE_TRANSFERS"), inventoryHandler.CompleteStockTransfer)
 				inventory.DELETE("/transfers/:id", middleware.RequirePermission("CREATE_TRANSFERS"), inventoryHandler.CancelStockTransfer)
 			}


### PR DESCRIPTION
## Summary
- add approve endpoint for stock transfers with permission guard
- implement approval handler and service logic transitioning transfers to in-transit status
- require in-transit status before completing a transfer

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a21bee8f68832c9bff483e9b716031